### PR TITLE
Task implement-message-components: Have the component-builder subagent create reusabl

### DIFF
--- a/src/components/ChatInterface/ChatInterface.module.css
+++ b/src/components/ChatInterface/ChatInterface.module.css
@@ -1,0 +1,61 @@
+.chatInterface {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-height: 800px;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  background-color: #f8f9fa;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.clearButton {
+  padding: 8px 16px;
+  border: 1px solid #dc3545;
+  border-radius: 6px;
+  background-color: transparent;
+  color: #dc3545;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: all 0.2s ease;
+}
+
+.clearButton:hover {
+  background-color: #dc3545;
+  color: white;
+}
+
+@media (max-width: 768px) {
+  .chatInterface {
+    height: 100vh;
+    border-radius: 0;
+    max-height: none;
+  }
+  
+  .header {
+    padding: 12px 16px;
+  }
+  
+  .title {
+    font-size: 1.125rem;
+  }
+}

--- a/src/components/ChatInterface/ChatInterface.tsx
+++ b/src/components/ChatInterface/ChatInterface.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useChatState } from '../../hooks/useChatState';
+import { MessageList } from '../MessageList/MessageList';
+import { MessageInput } from '../MessageInput/MessageInput';
+import styles from './ChatInterface.module.css';
+
+interface ChatInterfaceProps {
+  onSendMessage?: (message: string) => Promise<string>;
+  title?: string;
+}
+
+export const ChatInterface: React.FC<ChatInterfaceProps> = ({
+  onSendMessage,
+  title = "Chat"
+}) => {
+  const { messages, isLoading, addMessage, setLoading, clearMessages } = useChatState();
+
+  const handleSendMessage = async (message: string) => {
+    if (!message.trim()) return;
+
+    // Add user message
+    addMessage(message, 'user');
+
+    if (onSendMessage) {
+      setLoading(true);
+      try {
+        const response = await onSendMessage(message);
+        addMessage(response, 'assistant');
+      } catch (error) {
+        addMessage('Sorry, I encountered an error. Please try again.', 'assistant');
+        console.error('Chat error:', error);
+      } finally {
+        setLoading(false);
+      }
+    } else {
+      // Demo mode - echo message
+      setTimeout(() => {
+        addMessage(`Echo: ${message}`, 'assistant');
+      }, 1000);
+    }
+  };
+
+  return (
+    <div className={styles.chatInterface}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>{title}</h2>
+        <button
+          onClick={clearMessages}
+          className={styles.clearButton}
+          aria-label="Clear chat"
+        >
+          Clear
+        </button>
+      </div>
+      
+      <MessageList messages={messages} isLoading={isLoading} />
+      
+      <MessageInput
+        onSendMessage={handleSendMessage}
+        disabled={isLoading}
+        placeholder="Type your message..."
+      />
+    </div>
+  );
+};

--- a/src/components/MessageBubble/MessageBubble.module.css
+++ b/src/components/MessageBubble/MessageBubble.module.css
@@ -1,0 +1,55 @@
+.bubble {
+  max-width: 70%;
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  word-wrap: break-word;
+  animation: fadeIn 0.3s ease-in;
+}
+
+.user {
+  align-self: flex-end;
+  background-color: #007bff;
+  color: white;
+  margin-left: auto;
+}
+
+.assistant {
+  align-self: flex-start;
+  background-color: #f1f3f5;
+  color: #333;
+  margin-right: auto;
+}
+
+.content {
+  margin-bottom: 4px;
+  line-height: 1.4;
+}
+
+.timestamp {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  text-align: right;
+}
+
+.assistant .timestamp {
+  text-align: left;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .bubble {
+    max-width: 85%;
+    padding: 10px 14px;
+  }
+}

--- a/src/components/MessageBubble/MessageBubble.tsx
+++ b/src/components/MessageBubble/MessageBubble.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Message } from '../../types/chat';
+import styles from './MessageBubble.module.css';
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
+  const formatTime = (date: Date) => {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div className={`${styles.bubble} ${styles[message.sender]}`}>
+      <div className={styles.content}>
+        {message.content}
+      </div>
+      <div className={styles.timestamp}>
+        {formatTime(message.timestamp)}
+      </div>
+    </div>
+  );
+};

--- a/src/components/MessageInput/MessageInput.module.css
+++ b/src/components/MessageInput/MessageInput.module.css
@@ -1,0 +1,73 @@
+.inputContainer {
+  padding: 20px;
+  border-top: 1px solid #e9ecef;
+  background-color: white;
+}
+
+.inputWrapper {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  max-width: 100%;
+}
+
+.textarea {
+  flex: 1;
+  min-height: 44px;
+  max-height: 120px;
+  padding: 12px 16px;
+  border: 2px solid #e9ecef;
+  border-radius: 22px;
+  resize: none;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.4;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.textarea:focus {
+  border-color: #007bff;
+}
+
+.textarea:disabled {
+  background-color: #f8f9fa;
+  cursor: not-allowed;
+}
+
+.sendButton {
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background-color: #007bff;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+  flex-shrink: 0;
+}
+
+.sendButton:hover:not(:disabled) {
+  background-color: #0056b3;
+  transform: scale(1.05);
+}
+
+.sendButton:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+  transform: none;
+}
+
+@media (max-width: 768px) {
+  .inputContainer {
+    padding: 16px;
+  }
+  
+  .sendButton {
+    width: 40px;
+    height: 40px;
+  }
+}

--- a/src/components/MessageInput/MessageInput.tsx
+++ b/src/components/MessageInput/MessageInput.tsx
@@ -1,0 +1,57 @@
+import React, { useState, KeyboardEvent } from 'react';
+import styles from './MessageInput.module.css';
+
+interface MessageInputProps {
+  onSendMessage: (message: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export const MessageInput: React.FC<MessageInputProps> = ({
+  onSendMessage,
+  disabled = false,
+  placeholder = "Type your message..."
+}) => {
+  const [message, setMessage] = useState('');
+
+  const handleSend = () => {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage || disabled) return;
+
+    onSendMessage(trimmedMessage);
+    setMessage('');
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className={styles.inputContainer}>
+      <div className={styles.inputWrapper}>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={styles.textarea}
+          rows={1}
+        />
+        <button
+          onClick={handleSend}
+          disabled={disabled || !message.trim()}
+          className={styles.sendButton}
+          aria-label="Send message"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MessageList/MessageList.module.css
+++ b/src/components/MessageList/MessageList.module.css
@@ -1,0 +1,64 @@
+.messageList {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.emptyState {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  color: #666;
+  font-style: italic;
+}
+
+.loadingIndicator {
+  align-self: flex-start;
+  margin-right: auto;
+  padding: 12px 16px;
+  background-color: #f1f3f5;
+  border-radius: 18px;
+  margin-bottom: 16px;
+}
+
+.typingDots {
+  display: flex;
+  gap: 4px;
+}
+
+.typingDots span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #666;
+  animation: typing 1.4s infinite ease-in-out;
+}
+
+.typingDots span:nth-child(1) {
+  animation-delay: -0.32s;
+}
+
+.typingDots span:nth-child(2) {
+  animation-delay: -0.16s;
+}
+
+@keyframes typing {
+  0%, 80%, 100% {
+    transform: scale(0.8);
+    opacity: 0.5;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .messageList {
+    padding: 16px;
+  }
+}

--- a/src/components/MessageList/MessageList.tsx
+++ b/src/components/MessageList/MessageList.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+import { Message } from '../../types/chat';
+import { MessageBubble } from '../MessageBubble/MessageBubble';
+import styles from './MessageList.module.css';
+
+interface MessageListProps {
+  messages: Message[];
+  isLoading: boolean;
+}
+
+export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading }) => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  return (
+    <div className={styles.messageList}>
+      {messages.length === 0 ? (
+        <div className={styles.emptyState}>
+          <p>Start a conversation...</p>
+        </div>
+      ) : (
+        messages.map(message => (
+          <MessageBubble key={message.id} message={message} />
+        ))
+      )}
+      
+      {isLoading && (
+        <div className={styles.loadingIndicator}>
+          <div className={styles.typingDots}>
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+      )}
+      
+      <div ref={messagesEndRef} />
+    </div>
+  );
+};

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -1,0 +1,120 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { ChatStateProvider } from './ChatStateContext';
+import { MessageList } from './MessageList';
+import { MessageInput } from './MessageInput';
+import { SpecificationPanel } from './SpecificationPanel';
+import { ProjectSelector } from './ProjectSelector';
+import { useChatWebSocket } from '../hooks/useChatWebSocket';
+import { useSpecificationSync } from '../hooks/useSpecificationSync';
+import { ChatMessage, Project, Specification } from '../types';
+
+interface ChatContainerProps {
+  initialProject?: Project;
+  onSpecificationUpdate?: (spec: Specification) => void;
+}
+
+export const ChatContainer: React.FC<ChatContainerProps> = ({
+  initialProject,
+  onSpecificationUpdate
+}) => {
+  const [selectedProject, setSelectedProject] = useState<Project | null>(initialProject || null);
+  const [isSpecPanelOpen, setIsSpecPanelOpen] = useState(true);
+
+  const {
+    messages,
+    isConnected,
+    sendMessage,
+    clearChat,
+    isTyping
+  } = useChatWebSocket(selectedProject?.id);
+
+  const {
+    currentSpecification,
+    updateSpecification,
+    syncStatus
+  } = useSpecificationSync(selectedProject?.id);
+
+  const handleProjectChange = useCallback((project: Project) => {
+    setSelectedProject(project);
+    clearChat();
+  }, [clearChat]);
+
+  const handleMessageSend = useCallback((content: string, attachments?: File[]) => {
+    if (!selectedProject) {
+      throw new Error('No project selected');
+    }
+    
+    sendMessage({
+      content,
+      attachments,
+      projectId: selectedProject.id,
+      timestamp: new Date()
+    });
+  }, [selectedProject, sendMessage]);
+
+  useEffect(() => {
+    if (currentSpecification && onSpecificationUpdate) {
+      onSpecificationUpdate(currentSpecification);
+    }
+  }, [currentSpecification, onSpecificationUpdate]);
+
+  if (!selectedProject) {
+    return (
+      <div className="chat-container chat-container--no-project">
+        <ProjectSelector onProjectSelect={setSelectedProject} />
+      </div>
+    );
+  }
+
+  return (
+    <ChatStateProvider
+      projectId={selectedProject.id}
+      initialMessages={messages}
+      specification={currentSpecification}
+    >
+      <div className="chat-container">
+        <header className="chat-header">
+          <ProjectSelector
+            selectedProject={selectedProject}
+            onProjectSelect={handleProjectChange}
+          />
+          <div className="chat-controls">
+            <button
+              className="btn btn--secondary"
+              onClick={() => setIsSpecPanelOpen(!isSpecPanelOpen)}
+            >
+              {isSpecPanelOpen ? 'Hide' : 'Show'} Specification
+            </button>
+            <div className={`connection-status ${isConnected ? 'connected' : 'disconnected'}`}>
+              {isConnected ? '🟢' : '🔴'}
+            </div>
+          </div>
+        </header>
+
+        <div className="chat-body">
+          <div className="chat-main">
+            <MessageList
+              messages={messages}
+              isTyping={isTyping}
+              projectId={selectedProject.id}
+            />
+            <MessageInput
+              onSendMessage={handleMessageSend}
+              disabled={!isConnected}
+              placeholder="Describe your requirements..."
+            />
+          </div>
+
+          {isSpecPanelOpen && (
+            <SpecificationPanel
+              specification={currentSpecification}
+              syncStatus={syncStatus}
+              onUpdate={updateSpecification}
+              onClose={() => setIsSpecPanelOpen(false)}
+            />
+          )}
+        </div>
+      </div>
+    </ChatStateProvider>
+  );
+};

--- a/src/components/chat/ChatStateContext.tsx
+++ b/src/components/chat/ChatStateContext.tsx
@@ -1,0 +1,115 @@
+import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+import { ChatMessage, Specification, ChatState, ChatAction } from '../types';
+
+interface ChatStateContextType {
+  state: ChatState;
+  dispatch: React.Dispatch<ChatAction>;
+  addMessage: (message: ChatMessage) => void;
+  updateSpecification: (spec: Partial<Specification>) => void;
+  setTyping: (isTyping: boolean) => void;
+  clearMessages: () => void;
+}
+
+const ChatStateContext = createContext<ChatStateContextType | null>(null);
+
+const chatReducer = (state: ChatState, action: ChatAction): ChatState => {
+  switch (action.type) {
+    case 'ADD_MESSAGE':
+      return {
+        ...state,
+        messages: [...state.messages, action.payload],
+        lastActivity: new Date()
+      };
+    
+    case 'UPDATE_SPECIFICATION':
+      return {
+        ...state,
+        specification: state.specification 
+          ? { ...state.specification, ...action.payload }
+          : action.payload as Specification,
+        lastSpecUpdate: new Date()
+      };
+    
+    case 'SET_TYPING':
+      return {
+        ...state,
+        isTyping: action.payload
+      };
+    
+    case 'CLEAR_MESSAGES':
+      return {
+        ...state,
+        messages: [],
+        lastActivity: new Date()
+      };
+    
+    case 'SET_ERROR':
+      return {
+        ...state,
+        error: action.payload
+      };
+    
+    default:
+      return state;
+  }
+};
+
+interface ChatStateProviderProps {
+  children: ReactNode;
+  projectId: string;
+  initialMessages?: ChatMessage[];
+  specification?: Specification;
+}
+
+export const ChatStateProvider: React.FC<ChatStateProviderProps> = ({
+  children,
+  projectId,
+  initialMessages = [],
+  specification
+}) => {
+  const [state, dispatch] = useReducer(chatReducer, {
+    projectId,
+    messages: initialMessages,
+    specification,
+    isTyping: false,
+    lastActivity: new Date(),
+    error: null
+  });
+
+  const addMessage = (message: ChatMessage) => {
+    dispatch({ type: 'ADD_MESSAGE', payload: message });
+  };
+
+  const updateSpecification = (spec: Partial<Specification>) => {
+    dispatch({ type: 'UPDATE_SPECIFICATION', payload: spec });
+  };
+
+  const setTyping = (isTyping: boolean) => {
+    dispatch({ type: 'SET_TYPING', payload: isTyping });
+  };
+
+  const clearMessages = () => {
+    dispatch({ type: 'CLEAR_MESSAGES' });
+  };
+
+  return (
+    <ChatStateContext.Provider value={{
+      state,
+      dispatch,
+      addMessage,
+      updateSpecification,
+      setTyping,
+      clearMessages
+    }}>
+      {children}
+    </ChatStateContext.Provider>
+  );
+};
+
+export const useChatState = (): ChatStateContextType => {
+  const context = useContext(ChatStateContext);
+  if (!context) {
+    throw new Error('useChatState must be used within ChatStateProvider');
+  }
+  return context;
+};

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,0 +1,113 @@
+import React, { useState, useRef, KeyboardEvent } from 'react';
+import { AttachmentHandler } from './AttachmentHandler';
+
+interface MessageInputProps {
+  onSendMessage: (content: string, attachments?: File[]) => void;
+  disabled?: boolean;
+  placeholder?: string;
+  maxLength?: number;
+}
+
+export const MessageInput: React.FC<MessageInputProps> = ({
+  onSendMessage,
+  disabled = false,
+  placeholder = "Type your message...",
+  maxLength = 2000
+}) => {
+  const [message, setMessage] = useState('');
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSubmit = () => {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage && attachments.length === 0) return;
+    
+    if (trimmedMessage.length > maxLength) {
+      throw new Error(`Message too long. Maximum ${maxLength} characters allowed.`);
+    }
+
+    onSendMessage(trimmedMessage, attachments);
+    setMessage('');
+    setAttachments([]);
+    
+    // Reset textarea height
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+    
+    // Auto-resize textarea
+    const textarea = e.target;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 120)}px`;
+  };
+
+  const removeAttachment = (index: number) => {
+    setAttachments(prev => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="message-input">
+      {attachments.length > 0 && (
+        <div className="attachments-preview">
+          {attachments.map((file, index) => (
+            <div key={index} className="attachment-item">
+              <span className="attachment-name">{file.name}</span>
+              <button
+                type="button"
+                className="attachment-remove"
+                onClick={() => removeAttachment(index)}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      
+      <div className="input-container">
+        <AttachmentHandler
+          onAttachmentsChange={setAttachments}
+          disabled={disabled}
+        />
+        
+        <textarea
+          ref={textareaRef}
+          value={message}
+          onChange={handleTextareaChange}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={disabled}
+          className="message-textarea"
+          rows={1}
+          maxLength={maxLength}
+        />
+        
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={disabled || (!message.trim() && attachments.length === 0)}
+          className="send-button"
+        >
+          Send
+        </button>
+      </div>
+      
+      <div className="input-footer">
+        <span className="character-count">
+          {message.length}/{maxLength}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useRef } from 'react';
+import { MessageItem } from './MessageItem';
+import { TypingIndicator } from './TypingIndicator';
+import { useChatState } from './ChatStateContext';
+import { ChatMessage } from '../types';
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  isTyping: boolean;
+  projectId: string;
+}
+
+export const MessageList: React.FC<MessageListProps> = ({
+  messages,
+  isTyping,
+  projectId
+}) => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { state } = useChatState();
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, isTyping]);
+
+  if (messages.length === 0) {
+    return (
+      <div className="message-list message-list--empty">
+        <div className="empty-state">
+          <h3>Start a conversation</h3>
+          <p>Describe your project requirements and I'll help you create a detailed specification.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="message-list">
+      <div className="messages-container">
+        {messages.map((message) => (
+          <MessageItem
+            key={message.id}
+            message={message}
+            projectId={projectId}
+          />
+        ))}
+        
+        {isTyping && <TypingIndicator />}
+        
+        <div ref={messagesEndRef} />
+      </div>
+      
+      {state.error && (
+        <div className="message-error">
+          <span className="error-icon">⚠️</span>
+          {state.error}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/messages/LoadingMessage.tsx
+++ b/src/components/messages/LoadingMessage.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { MessageBase } from './MessageBase';
+import { LoadingMessage as LoadingMessageType } from './types';
+import { Bot, Loader2 } from 'lucide-react';
+
+interface LoadingMessageProps {
+  message: LoadingMessageType;
+}
+
+export const LoadingMessage: React.FC<LoadingMessageProps> = ({ message }) => {
+  return (
+    <MessageBase 
+      variant="loading"
+      role="status"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0">
+          <div className="w-8 h-8 bg-yellow-500 rounded-full flex items-center justify-center">
+            <Bot className="w-4 h-4 text-white" aria-hidden="true" />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-yellow-900 mb-1 flex items-center gap-2">
+            <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+            Assistant is thinking...
+          </div>
+          {message.message && (
+            <div className="text-gray-700 text-sm">
+              {message.message}
+            </div>
+          )}
+        </div>
+      </div>
+      <div 
+        className="sr-only" 
+        aria-live="polite" 
+        aria-atomic="true"
+      >
+        Loading response, please wait
+      </div>
+    </MessageBase>
+  );
+};

--- a/src/components/messages/MessageBase.tsx
+++ b/src/components/messages/MessageBase.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { cn } from '../../lib/utils';
+
+interface MessageBaseProps {
+  children: React.ReactNode;
+  className?: string;
+  variant?: 'user' | 'system' | 'spec' | 'loading';
+  timestamp?: Date;
+  role?: string;
+}
+
+export const MessageBase: React.FC<MessageBaseProps> = ({
+  children,
+  className,
+  variant = 'system',
+  timestamp,
+  role
+}) => {
+  const baseClasses = "flex flex-col gap-2 p-4 rounded-lg max-w-4xl";
+  
+  const variantClasses = {
+    user: "bg-blue-50 border-l-4 border-blue-500 ml-auto",
+    system: "bg-gray-50 border-l-4 border-gray-400",
+    spec: "bg-slate-50 border border-slate-200",
+    loading: "bg-yellow-50 border-l-4 border-yellow-400"
+  };
+
+  return (
+    <div
+      className={cn(baseClasses, variantClasses[variant], className)}
+      role={role || "article"}
+      aria-label={`${variant} message`}
+    >
+      {children}
+      {timestamp && (
+        <time 
+          className="text-xs text-gray-500 mt-2"
+          dateTime={timestamp.toISOString()}
+          aria-label={`Sent at ${timestamp.toLocaleString()}`}
+        >
+          {timestamp.toLocaleTimeString()}
+        </time>
+      )}
+    </div>
+  );
+};

--- a/src/components/messages/MessageContainer.tsx
+++ b/src/components/messages/MessageContainer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Message } from './types';
+import { UserMessage } from './UserMessage';
+import { SystemMessage } from './SystemMessage';
+import { SpecPreview } from './SpecPreview';
+import { LoadingMessage } from './LoadingMessage';
+
+interface MessageContainerProps {
+  messages: Message[];
+  className?: string;
+}
+
+export const MessageContainer: React.FC<MessageContainerProps> = ({ 
+  messages, 
+  className = '' 
+}) => {
+  const renderMessage = (message: Message) => {
+    switch (message.type) {
+      case 'user':
+        return <UserMessage key={message.id} message={message} />;
+      case 'system':
+        return <SystemMessage key={message.id} message={message} />;
+      case 'spec':
+        return <SpecPreview key={message.id} message={message} />;
+      case 'loading':
+        return <LoadingMessage key={message.id} message={message} />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div 
+      className={`flex flex-col gap-4 p-4 ${className}`}
+      role="log"
+      aria-label="Conversation messages"
+    >
+      {messages.map(renderMessage)}
+    </div>
+  );
+};

--- a/src/components/messages/SpecPreview.tsx
+++ b/src/components/messages/SpecPreview.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import { MessageBase } from './MessageBase';
+import { SpecPreview as SpecPreviewType } from './types';
+import { Code, ChevronDown, ChevronRight, Copy, Check } from 'lucide-react';
+
+interface SpecPreviewProps {
+  message: SpecPreviewType;
+}
+
+export const SpecPreview: React.FC<SpecPreviewProps> = ({ message }) => {
+  const [isExpanded, setIsExpanded] = useState(!message.isCollapsible);
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  const toggleExpanded = () => {
+    if (message.isCollapsible) {
+      setIsExpanded(!isExpanded);
+    }
+  };
+
+  return (
+    <MessageBase 
+      variant="spec" 
+      timestamp={message.timestamp}
+      role="article"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div 
+          className={`flex items-center gap-2 ${message.isCollapsible ? 'cursor-pointer' : ''}`}
+          onClick={toggleExpanded}
+          role={message.isCollapsible ? 'button' : undefined}
+          tabIndex={message.isCollapsible ? 0 : undefined}
+          onKeyDown={(e) => {
+            if (message.isCollapsible && (e.key === 'Enter' || e.key === ' ')) {
+              e.preventDefault();
+              toggleExpanded();
+            }
+          }}
+          aria-expanded={message.isCollapsible ? isExpanded : undefined}
+          aria-label={message.isCollapsible ? `${isExpanded ? 'Collapse' : 'Expand'} code preview` : undefined}
+        >
+          {message.isCollapsible && (
+            isExpanded ? 
+              <ChevronDown className="w-4 h-4 text-gray-500" aria-hidden="true" /> : 
+              <ChevronRight className="w-4 h-4 text-gray-500" aria-hidden="true" />
+          )}
+          <Code className="w-4 h-4 text-slate-600" aria-hidden="true" />
+          <span className="text-sm font-medium text-slate-700">
+            {message.filename || `${message.language} Code`}
+          </span>
+          <span className="text-xs text-slate-500 bg-slate-200 px-2 py-1 rounded">
+            {message.language}
+          </span>
+        </div>
+        
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1 px-2 py-1 text-xs text-slate-600 hover:text-slate-800 hover:bg-slate-200 rounded transition-colors"
+          aria-label="Copy code to clipboard"
+        >
+          {isCopied ? (
+            <>
+              <Check className="w-3 h-3" aria-hidden="true" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="w-3 h-3" aria-hidden="true" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      {isExpanded && (
+        <div className="relative">
+          <pre className="bg-slate-900 text-slate-100 p-4 rounded-md overflow-x-auto text-sm">
+            <code className={`language-${message.language}`}>
+              {message.content}
+            </code>
+          </pre>
+        </div>
+      )}
+    </MessageBase>
+  );
+};

--- a/src/components/messages/SystemMessage.tsx
+++ b/src/components/messages/SystemMessage.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { MessageBase } from './MessageBase';
+import { SystemMessage as SystemMessageType } from './types';
+import { Bot, Info, CheckCircle, AlertTriangle, XCircle } from 'lucide-react';
+
+interface SystemMessageProps {
+  message: SystemMessageType;
+}
+
+const variantConfig = {
+  info: {
+    icon: Info,
+    iconColor: 'text-blue-500',
+    titleColor: 'text-blue-900'
+  },
+  success: {
+    icon: CheckCircle,
+    iconColor: 'text-green-500',
+    titleColor: 'text-green-900'
+  },
+  warning: {
+    icon: AlertTriangle,
+    iconColor: 'text-yellow-500',
+    titleColor: 'text-yellow-900'
+  },
+  error: {
+    icon: XCircle,
+    iconColor: 'text-red-500',
+    titleColor: 'text-red-900'
+  }
+};
+
+export const SystemMessage: React.FC<SystemMessageProps> = ({ message }) => {
+  const variant = message.variant || 'info';
+  const config = variantConfig[variant];
+  const Icon = config.icon;
+
+  return (
+    <MessageBase 
+      variant="system" 
+      timestamp={message.timestamp}
+      role="article"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0">
+          <div className="w-8 h-8 bg-gray-500 rounded-full flex items-center justify-center">
+            <Bot className="w-4 h-4 text-white" aria-hidden="true" />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className={`text-sm font-medium mb-1 flex items-center gap-2 ${config.titleColor}`}>
+            <Icon className={`w-4 h-4 ${config.iconColor}`} aria-hidden="true" />
+            Assistant
+          </div>
+          <div className="text-gray-800 whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+        </div>
+      </div>
+    </MessageBase>
+  );
+};

--- a/src/components/messages/UserMessage.tsx
+++ b/src/components/messages/UserMessage.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { MessageBase } from './MessageBase';
+import { UserMessage as UserMessageType } from './types';
+import { User } from 'lucide-react';
+
+interface UserMessageProps {
+  message: UserMessageType;
+}
+
+export const UserMessage: React.FC<UserMessageProps> = ({ message }) => {
+  return (
+    <MessageBase 
+      variant="user" 
+      timestamp={message.timestamp}
+      role="article"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0">
+          {message.avatar ? (
+            <img
+              src={message.avatar}
+              alt="User avatar"
+              className="w-8 h-8 rounded-full"
+            />
+          ) : (
+            <div className="w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center">
+              <User className="w-4 h-4 text-white" aria-hidden="true" />
+            </div>
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-blue-900 mb-1">
+            You
+          </div>
+          <div className="text-gray-800 whitespace-pre-wrap break-words">
+            {message.content}
+          </div>
+        </div>
+      </div>
+    </MessageBase>
+  );
+};

--- a/src/components/messages/__tests__/MessageBase.test.tsx
+++ b/src/components/messages/__tests__/MessageBase.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MessageBase } from '../MessageBase';
+
+describe('MessageBase', () => {
+  it('renders children correctly', () => {
+    render(
+      <MessageBase>
+        <div>Test content</div>
+      </MessageBase>
+    );
+    
+    expect(screen.getByText('Test content')).toBeInTheDocument();
+  });
+
+  it('applies correct variant classes', () => {
+    const { container } = render(
+      <MessageBase variant="user">
+        <div>User message</div>
+      </MessageBase>
+    );
+    
+    expect(container.firstChild).toHaveClass('bg-blue-50', 'border-blue-500');
+  });
+
+  it('displays timestamp when provided', () => {
+    const timestamp = new Date('2023-01-01T12:00:00Z');
+    render(
+      <MessageBase timestamp={timestamp}>
+        <div>Content</div>
+      </MessageBase>
+    );
+    
+    expect(screen.getByRole('time')).toBeInTheDocument();
+  });
+
+  it('has proper accessibility attributes', () => {
+    render(
+      <MessageBase variant="system">
+        <div>System message</div>
+      </MessageBase>
+    );
+    
+    expect(screen.getByRole('article')).toHaveAttribute('aria-label', 'system message');
+  });
+});

--- a/src/components/messages/index.ts
+++ b/src/components/messages/index.ts
@@ -1,0 +1,7 @@
+export { MessageContainer } from './MessageContainer';
+export { UserMessage } from './UserMessage';
+export { SystemMessage } from './SystemMessage';
+export { SpecPreview } from './SpecPreview';
+export { LoadingMessage } from './LoadingMessage';
+export { MessageBase } from './MessageBase';
+export type * from './types';

--- a/src/components/messages/types.ts
+++ b/src/components/messages/types.ts
@@ -1,0 +1,30 @@
+export interface BaseMessage {
+  id: string;
+  timestamp: Date;
+  content: string;
+}
+
+export interface UserMessage extends BaseMessage {
+  type: 'user';
+  avatar?: string;
+}
+
+export interface SystemMessage extends BaseMessage {
+  type: 'system';
+  variant?: 'info' | 'success' | 'warning' | 'error';
+}
+
+export interface SpecPreview extends BaseMessage {
+  type: 'spec';
+  language: string;
+  filename?: string;
+  isCollapsible?: boolean;
+}
+
+export interface LoadingMessage {
+  id: string;
+  type: 'loading';
+  message?: string;
+}
+
+export type Message = UserMessage | SystemMessage | SpecPreview | LoadingMessage;

--- a/src/hooks/useChatState.ts
+++ b/src/hooks/useChatState.ts
@@ -1,0 +1,38 @@
+import { useState, useCallback } from 'react';
+import { Message, ChatState } from '../types/chat';
+
+export const useChatState = () => {
+  const [state, setState] = useState<ChatState>({
+    messages: [],
+    isLoading: false
+  });
+
+  const addMessage = useCallback((content: string, sender: 'user' | 'assistant') => {
+    const newMessage: Message = {
+      id: Date.now().toString(),
+      content: content.trim(),
+      sender,
+      timestamp: new Date()
+    };
+
+    setState(prev => ({
+      ...prev,
+      messages: [...prev.messages, newMessage]
+    }));
+  }, []);
+
+  const setLoading = useCallback((loading: boolean) => {
+    setState(prev => ({ ...prev, isLoading: loading }));
+  }, []);
+
+  const clearMessages = useCallback(() => {
+    setState({ messages: [], isLoading: false });
+  }, []);
+
+  return {
+    ...state,
+    addMessage,
+    setLoading,
+    clearMessages
+  };
+};

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,11 @@
+export interface Message {
+  id: string;
+  content: string;
+  sender: 'user' | 'assistant';
+  timestamp: Date;
+}
+
+export interface ChatState {
+  messages: Message[];
+  isLoading: boolean;
+}


### PR DESCRIPTION
## Task Description
Have the component-builder subagent create reusable message components for different types of content (user messages, system responses, spec previews, loading states) with proper styling and accessibility features

## Automated Implementation
This PR was created by FDJ Code CLI using Claude Sonnet 4 via AWS Bedrock.

**Task ID:** `implement-message-components`  
**Branch:** `fix-implement-message-components-1757440983`  
**Provider:** `claude-bedrock`

---
*Generated by [FDJ Code CLI](https://github.com/durdan/dd-agentic-pipeline) • Powered by Claude Sonnet 4*
