### PR TITLE
Task create-spec-types: Have the specification-expert subagent implement h

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+@dataclass
+class SpecificationConfig:
+    """Configuration for specification generation"""
+    template_style: str = "standard"
+    detail_level: str = "medium"  # low, medium, high
+    include_examples: bool = True
+    include_diagrams: bool = False
+    custom_sections: Optional[list] = None
+    metadata: Optional[Dict[str, Any]] = None
+    
+    def __post_init__(self):
+        if self.detail_level not in ["low", "medium", "high"]:
+            raise ValueError("detail_level must be 'low', 'medium', or 'high'")
+        if self.custom_sections is None:
+            self.custom_sections = []
+        if self.metadata is None:
+            self.metadata = {}

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,3 @@
+class ValidationError(Exception):
+    """Raised when input validation fails"""
+    pass

--- a/handlers/api_docs.py
+++ b/handlers/api_docs.py
@@ -1,0 +1,60 @@
+from typing import Dict, Any
+from .base import SpecificationHandler
+from ..exceptions import ValidationError
+
+class ApiDocHandler(SpecificationHandler):
+    """Handler for API documentation specifications"""
+    
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        required_fields = ["api_name", "endpoints"]
+        for field in required_fields:
+            if field not in input_data:
+                raise ValidationError(f"Missing required field: {field}")
+    
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_input(input_data)
+        
+        content = {
+            "title": f"API Documentation: {input_data['api_name']}",
+            "sections": {
+                "overview": self._generate_api_overview(input_data),
+                "authentication": input_data.get("authentication", {}),
+                "base_url": input_data.get("base_url", ""),
+                "endpoints": self._process_endpoints(input_data["endpoints"]),
+                "error_codes": input_data.get("error_codes", {}),
+                "rate_limiting": input_data.get("rate_limiting", {})
+            }
+        }
+        
+        if self.config.include_examples:
+            content["sections"]["examples"] = self._generate_api_examples()
+        
+        return self._add_metadata(content)
+    
+    def _generate_api_overview(self, input_data: Dict[str, Any]) -> str:
+        return f"API documentation for {input_data['api_name']} - {input_data.get('description', '')}"
+    
+    def _process_endpoints(self, endpoints: list) -> list:
+        processed = []
+        for endpoint in endpoints:
+            processed_endpoint = {
+                "path": endpoint.get("path", ""),
+                "method": endpoint.get("method", "GET"),
+                "description": endpoint.get("description", ""),
+                "parameters": endpoint.get("parameters", []),
+                "request_body": endpoint.get("request_body", {}),
+                "responses": endpoint.get("responses", {})
+            }
+            
+            if self.config.detail_level == "high":
+                processed_endpoint["headers"] = endpoint.get("headers", [])
+                processed_endpoint["security"] = endpoint.get("security", [])
+            
+            processed.append(processed_endpoint)
+        return processed
+    
+    def _generate_api_examples(self) -> Dict[str, Any]:
+        return {
+            "request_examples": ["Sample GET request", "Sample POST request"],
+            "response_examples": ["Success response", "Error response"]
+        }

--- a/handlers/architecture_specs.py
+++ b/handlers/architecture_specs.py
@@ -1,0 +1,52 @@
+from typing import Dict, Any
+from .base import SpecificationHandler
+from ..exceptions import ValidationError
+
+class ArchitectureSpecHandler(SpecificationHandler):
+    """Handler for architecture specification documents"""
+    
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        required_fields = ["system_name", "components"]
+        for field in required_fields:
+            if field not in input_data:
+                raise ValidationError(f"Missing required field: {field}")
+    
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_input(input_data)
+        
+        content = {
+            "title": f"Architecture Specification: {input_data['system_name']}",
+            "sections": {
+                "overview": self._generate_overview(input_data),
+                "components": self._process_components(input_data["components"]),
+                "data_flow": input_data.get("data_flow", []),
+                "security": input_data.get("security_requirements", {}),
+                "scalability": input_data.get("scalability_requirements", {}),
+                "deployment": input_data.get("deployment_strategy", {})
+            }
+        }
+        
+        if self.config.include_diagrams:
+            content["sections"]["diagrams"] = self._generate_diagram_specs()
+        
+        return self._add_metadata(content)
+    
+    def _generate_overview(self, input_data: Dict[str, Any]) -> str:
+        return f"Architecture specification for {input_data['system_name']} system"
+    
+    def _process_components(self, components: list) -> list:
+        processed = []
+        for component in components:
+            processed_component = {
+                "name": component.get("name", "Unnamed component"),
+                "responsibility": component.get("responsibility", ""),
+                "interfaces": component.get("interfaces", []),
+                "dependencies": component.get("dependencies", [])
+            }
+            if self.config.detail_level == "high":
+                processed_component["implementation_details"] = component.get("implementation_details", {})
+            processed.append(processed_component)
+        return processed
+    
+    def _generate_diagram_specs(self) -> list:
+        return ["System context diagram", "Component diagram", "Deployment diagram"]

--- a/handlers/base.py
+++ b/handlers/base.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+from ..config import SpecificationConfig
+
+class SpecificationHandler(ABC):
+    """Abstract base class for specification handlers"""
+    
+    def __init__(self, config: SpecificationConfig):
+        self.config = config
+    
+    @abstractmethod
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate specification content from input data"""
+        pass
+    
+    @abstractmethod
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        """Validate input data for this specification type"""
+        pass
+    
+    def _add_metadata(self, content: Dict[str, Any]) -> Dict[str, Any]:
+        """Add metadata to generated content"""
+        content["metadata"] = {
+            "generated_by": self.__class__.__name__,
+            "config": self.config.__dict__,
+            **self.config.metadata
+        }
+        return content

--- a/handlers/business_analysis.py
+++ b/handlers/business_analysis.py
@@ -1,0 +1,44 @@
+from typing import Dict, Any
+from .base import SpecificationHandler
+from ..exceptions import ValidationError
+
+class BusinessAnalysisHandler(SpecificationHandler):
+    """Handler for business analysis specifications"""
+    
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        required_fields = ["project_name", "business_objectives"]
+        for field in required_fields:
+            if field not in input_data:
+                raise ValidationError(f"Missing required field: {field}")
+    
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_input(input_data)
+        
+        content = {
+            "title": f"Business Analysis: {input_data['project_name']}",
+            "sections": {
+                "executive_summary": self._generate_executive_summary(input_data),
+                "business_objectives": input_data["business_objectives"],
+                "stakeholders": input_data.get("stakeholders", []),
+                "requirements": self._generate_requirements(input_data),
+                "risks": input_data.get("risks", []),
+                "success_criteria": input_data.get("success_criteria", [])
+            }
+        }
+        
+        if self.config.include_examples:
+            content["sections"]["examples"] = self._generate_examples()
+        
+        return self._add_metadata(content)
+    
+    def _generate_executive_summary(self, input_data: Dict[str, Any]) -> str:
+        return f"Business analysis for {input_data['project_name']} focusing on achieving defined objectives."
+    
+    def _generate_requirements(self, input_data: Dict[str, Any]) -> list:
+        base_requirements = input_data.get("requirements", [])
+        if self.config.detail_level == "high":
+            base_requirements.extend(["Detailed requirement analysis", "Impact assessment"])
+        return base_requirements
+    
+    def _generate_examples(self) -> list:
+        return ["Sample business case", "ROI calculation example"]

--- a/handlers/test_specs.py
+++ b/handlers/test_specs.py
@@ -1,0 +1,50 @@
+from typing import Dict, Any
+from .base import SpecificationHandler
+from ..exceptions import ValidationError
+
+class TestSpecHandler(SpecificationHandler):
+    """Handler for test specification documents"""
+    
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        required_fields = ["feature_name", "test_scenarios"]
+        for field in required_fields:
+            if field not in input_data:
+                raise ValidationError(f"Missing required field: {field}")
+    
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_input(input_data)
+        
+        content = {
+            "title": f"Test Specification: {input_data['feature_name']}",
+            "sections": {
+                "test_overview": self._generate_test_overview(input_data),
+                "test_scenarios": self._process_test_scenarios(input_data["test_scenarios"]),
+                "test_data": input_data.get("test_data", {}),
+                "environment": input_data.get("environment", "staging"),
+                "acceptance_criteria": input_data.get("acceptance_criteria", [])
+            }
+        }
+        
+        if self.config.detail_level == "high":
+            content["sections"]["detailed_steps"] = self._generate_detailed_steps()
+        
+        return self._add_metadata(content)
+    
+    def _generate_test_overview(self, input_data: Dict[str, Any]) -> str:
+        return f"Comprehensive test specification for {input_data['feature_name']}"
+    
+    def _process_test_scenarios(self, scenarios: list) -> list:
+        processed = []
+        for scenario in scenarios:
+            processed_scenario = {
+                "name": scenario.get("name", "Unnamed scenario"),
+                "steps": scenario.get("steps", []),
+                "expected_result": scenario.get("expected_result", "")
+            }
+            if self.config.include_examples:
+                processed_scenario["example_data"] = scenario.get("example_data", {})
+            processed.append(processed_scenario)
+        return processed
+    
+    def _generate_detailed_steps(self) -> list:
+        return ["Setup test environment", "Execute test cases", "Validate results", "Cleanup"]

--- a/handlers/user_stories.py
+++ b/handlers/user_stories.py
@@ -1,0 +1,59 @@
+from typing import Dict, Any
+from .base import SpecificationHandler
+from ..exceptions import ValidationError
+
+class UserStoryHandler(SpecificationHandler):
+    """Handler for user story specifications"""
+    
+    def validate_input(self, input_data: Dict[str, Any]) -> None:
+        required_fields = ["epic_name", "stories"]
+        for field in required_fields:
+            if field not in input_data:
+                raise ValidationError(f"Missing required field: {field}")
+    
+    def generate(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
+        self.validate_input(input_data)
+        
+        content = {
+            "title": f"User Stories: {input_data['epic_name']}",
+            "sections": {
+                "epic_overview": self._generate_epic_overview(input_data),
+                "user_stories": self._process_user_stories(input_data["stories"]),
+                "acceptance_criteria": self._generate_acceptance_criteria(input_data),
+                "definition_of_done": input_data.get("definition_of_done", [])
+            }
+        }
+        
+        return self._add_metadata(content)
+    
+    def _generate_epic_overview(self, input_data: Dict[str, Any]) -> str:
+        return f"Epic: {input_data['epic_name']} - {input_data.get('epic_description', '')}"
+    
+    def _process_user_stories(self, stories: list) -> list:
+        processed = []
+        for story in stories:
+            processed_story = {
+                "id": story.get("id", ""),
+                "title": story.get("title", ""),
+                "as_a": story.get("as_a", "user"),
+                "i_want": story.get("i_want", ""),
+                "so_that": story.get("so_that", ""),
+                "priority": story.get("priority", "medium"),
+                "story_points": story.get("story_points", 0)
+            }
+            
+            if self.config.include_examples:
+                processed_story["examples"] = story.get("examples", [])
+            
+            if self.config.detail_level == "high":
+                processed_story["detailed_acceptance_criteria"] = story.get("acceptance_criteria", [])
+            
+            processed.append(processed_story)
+        return processed
+    
+    def _generate_acceptance_criteria(self, input_data: Dict[str, Any]) -> list:
+        criteria = []
+        for story in input_data["stories"]:
+            if "acceptance_criteria" in story:
+                criteria.extend(story["acceptance_criteria"])
+        return criteria

--- a/models.py
+++ b/models.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional
+from enum import Enum
+
+class SpecificationType(Enum):
+    FUNCTIONAL = "functional"
+    TECHNICAL = "technical"
+    UI_UX = "ui_ux"
+    API = "api"
+    DATABASE = "database"
+    SECURITY = "security"
+    PERFORMANCE = "performance"
+    INTEGRATION = "integration"
+
+class Priority(Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+@dataclass
+class Requirement:
+    id: str
+    text: str
+    category: str
+    priority: Priority
+    entities: List[str]
+    keywords: List[str]
+    confidence: float
+
+@dataclass
+class SpecificationNeeds:
+    types: List[SpecificationType]
+    complexity: str  # simple, moderate, complex
+    estimated_effort: str  # low, medium, high
+    dependencies: List[str]
+
+@dataclass
+class StructuredInput:
+    requirements: List[Requirement]
+    specification_needs: SpecificationNeeds
+    context: Dict[str, Any]
+    metadata: Dict[str, Any]

--- a/nlp_processor.py
+++ b/nlp_processor.py
@@ -1,0 +1,98 @@
+import re
+from typing import List, Dict, Set, Tuple
+from collections import Counter
+
+class NLPProcessor:
+    """Core NLP subagent for processing natural language text."""
+    
+    def __init__(self):
+        self.technical_keywords = {
+            'api', 'database', 'server', 'client', 'authentication', 'authorization',
+            'endpoint', 'rest', 'graphql', 'sql', 'nosql', 'cache', 'redis',
+            'microservice', 'docker', 'kubernetes', 'aws', 'azure', 'gcp'
+        }
+        
+        self.ui_keywords = {
+            'interface', 'ui', 'ux', 'design', 'layout', 'responsive', 'mobile',
+            'desktop', 'button', 'form', 'navigation', 'menu', 'dashboard',
+            'component', 'widget', 'theme', 'styling'
+        }
+        
+        self.functional_keywords = {
+            'user', 'customer', 'admin', 'login', 'register', 'search', 'filter',
+            'create', 'update', 'delete', 'manage', 'process', 'workflow',
+            'notification', 'email', 'report', 'export', 'import'
+        }
+        
+        self.priority_indicators = {
+            'critical': ['critical', 'urgent', 'must have', 'essential', 'required'],
+            'high': ['important', 'high priority', 'needed', 'should have'],
+            'medium': ['would like', 'nice to have', 'preferred', 'medium'],
+            'low': ['optional', 'if possible', 'low priority', 'future']
+        }
+
+    def extract_entities(self, text: str) -> List[str]:
+        """Extract named entities and important nouns from text."""
+        # Simple entity extraction - in production, use spaCy or similar
+        words = re.findall(r'\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b', text)
+        
+        # Extract technical terms and domain-specific entities
+        technical_entities = []
+        text_lower = text.lower()
+        
+        for keyword in self.technical_keywords | self.ui_keywords | self.functional_keywords:
+            if keyword in text_lower:
+                technical_entities.append(keyword)
+        
+        return list(set(words + technical_entities))
+
+    def extract_keywords(self, text: str) -> List[str]:
+        """Extract relevant keywords from text."""
+        # Remove common stop words and extract meaningful terms
+        stop_words = {'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by', 'is', 'are', 'was', 'were', 'be', 'been', 'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could', 'should'}
+        
+        words = re.findall(r'\b[a-zA-Z]+\b', text.lower())
+        keywords = [word for word in words if word not in stop_words and len(word) > 2]
+        
+        # Count frequency and return most common
+        word_freq = Counter(keywords)
+        return [word for word, _ in word_freq.most_common(10)]
+
+    def detect_priority(self, text: str) -> str:
+        """Detect priority level from text indicators."""
+        text_lower = text.lower()
+        
+        for priority, indicators in self.priority_indicators.items():
+            if any(indicator in text_lower for indicator in indicators):
+                return priority
+        
+        return 'medium'  # default
+
+    def categorize_requirement(self, text: str, entities: List[str], keywords: List[str]) -> str:
+        """Categorize requirement based on content analysis."""
+        text_lower = text.lower()
+        
+        # Count matches for each category
+        technical_score = sum(1 for word in keywords + entities if word.lower() in self.technical_keywords)
+        ui_score = sum(1 for word in keywords + entities if word.lower() in self.ui_keywords)
+        functional_score = sum(1 for word in keywords + entities if word.lower() in self.functional_keywords)
+        
+        # Determine category based on highest score
+        scores = {
+            'technical': technical_score,
+            'ui_ux': ui_score,
+            'functional': functional_score
+        }
+        
+        return max(scores, key=scores.get) if max(scores.values()) > 0 else 'general'
+
+    def calculate_confidence(self, text: str, entities: List[str], keywords: List[str]) -> float:
+        """Calculate confidence score for the extracted information."""
+        # Simple confidence calculation based on entity and keyword density
+        word_count = len(text.split())
+        entity_density = len(entities) / max(word_count, 1)
+        keyword_density = len(keywords) / max(word_count, 1)
+        
+        # Normalize to 0-1 range
+        confidence = min((entity_density + keyword_density) * 2, 1.0)
+        return round(confidence, 2)

--- a/requirement_extractor.py
+++ b/requirement_extractor.py
@@ -1,0 +1,64 @@
+from typing import List
+from models import Requirement, Priority
+from nlp_processor import NLPProcessor
+import uuid
+
+class RequirementExtractor:
+    """Extracts structured requirements from conversation text."""
+    
+    def __init__(self):
+        self.nlp_processor = NLPProcessor()
+    
+    def extract_requirements(self, conversation_text: str) -> List[Requirement]:
+        """Extract individual requirements from conversation text."""
+        if not conversation_text or not conversation_text.strip():
+            raise ValueError("Conversation text cannot be empty")
+        
+        # Split conversation into sentences/statements
+        sentences = self._split_into_statements(conversation_text)
+        
+        requirements = []
+        for sentence in sentences:
+            if self._is_requirement_statement(sentence):
+                requirement = self._create_requirement(sentence)
+                requirements.append(requirement)
+        
+        return requirements
+    
+    def _split_into_statements(self, text: str) -> List[str]:
+        """Split text into individual statements."""
+        import re
+        # Split on sentence boundaries, keeping meaningful statements
+        sentences = re.split(r'[.!?]+', text)
+        return [s.strip() for s in sentences if s.strip() and len(s.strip()) > 10]
+    
+    def _is_requirement_statement(self, statement: str) -> bool:
+        """Determine if a statement contains a requirement."""
+        requirement_indicators = [
+            'need', 'want', 'require', 'should', 'must', 'have to',
+            'would like', 'looking for', 'expect', 'feature', 'functionality'
+        ]
+        
+        statement_lower = statement.lower()
+        return any(indicator in statement_lower for indicator in requirement_indicators)
+    
+    def _create_requirement(self, statement: str) -> Requirement:
+        """Create a structured requirement from a statement."""
+        entities = self.nlp_processor.extract_entities(statement)
+        keywords = self.nlp_processor.extract_keywords(statement)
+        category = self.nlp_processor.categorize_requirement(statement, entities, keywords)
+        priority_str = self.nlp_processor.detect_priority(statement)
+        confidence = self.nlp_processor.calculate_confidence(statement, entities, keywords)
+        
+        # Convert priority string to enum
+        priority = Priority(priority_str)
+        
+        return Requirement(
+            id=str(uuid.uuid4()),
+            text=statement.strip(),
+            category=category,
+            priority=priority,
+            entities=entities,
+            keywords=keywords,
+            confidence=confidence
+        )

--- a/specification_classifier.py
+++ b/specification_classifier.py
@@ -1,0 +1,121 @@
+from typing import List
+from models import SpecificationType, SpecificationNeeds, Requirement
+
+class SpecificationClassifier:
+    """Identifies what types of specifications are needed based on requirements."""
+    
+    def __init__(self):
+        self.type_indicators = {
+            SpecificationType.FUNCTIONAL: [
+                'user', 'workflow', 'process', 'business', 'feature', 'functionality'
+            ],
+            SpecificationType.TECHNICAL: [
+                'api', 'database', 'server', 'architecture', 'technology', 'framework'
+            ],
+            SpecificationType.UI_UX: [
+                'interface', 'design', 'layout', 'user experience', 'responsive', 'mobile'
+            ],
+            SpecificationType.API: [
+                'endpoint', 'rest', 'graphql', 'integration', 'service', 'microservice'
+            ],
+            SpecificationType.DATABASE: [
+                'data', 'storage', 'sql', 'nosql', 'schema', 'model'
+            ],
+            SpecificationType.SECURITY: [
+                'authentication', 'authorization', 'security', 'permission', 'access'
+            ],
+            SpecificationType.PERFORMANCE: [
+                'performance', 'speed', 'optimization', 'scalability', 'load'
+            ],
+            SpecificationType.INTEGRATION: [
+                'integration', 'third-party', 'external', 'webhook', 'sync'
+            ]
+        }
+    
+    def classify_specification_needs(self, requirements: List[Requirement]) -> SpecificationNeeds:
+        """Classify what specification types are needed."""
+        if not requirements:
+            raise ValueError("Requirements list cannot be empty")
+        
+        needed_types = self._identify_needed_types(requirements)
+        complexity = self._assess_complexity(requirements, needed_types)
+        effort = self._estimate_effort(requirements, complexity)
+        dependencies = self._identify_dependencies(requirements)
+        
+        return SpecificationNeeds(
+            types=needed_types,
+            complexity=complexity,
+            estimated_effort=effort,
+            dependencies=dependencies
+        )
+    
+    def _identify_needed_types(self, requirements: List[Requirement]) -> List[SpecificationType]:
+        """Identify which specification types are needed."""
+        type_scores = {spec_type: 0 for spec_type in SpecificationType}
+        
+        for requirement in requirements:
+            all_text = f"{requirement.text} {' '.join(requirement.keywords)} {' '.join(requirement.entities)}"
+            text_lower = all_text.lower()
+            
+            for spec_type, indicators in self.type_indicators.items():
+                score = sum(1 for indicator in indicators if indicator in text_lower)
+                type_scores[spec_type] += score
+        
+        # Return types with non-zero scores
+        needed_types = [spec_type for spec_type, score in type_scores.items() if score > 0]
+        
+        # Always include functional if we have requirements
+        if needed_types and SpecificationType.FUNCTIONAL not in needed_types:
+            needed_types.append(SpecificationType.FUNCTIONAL)
+        
+        return needed_types or [SpecificationType.FUNCTIONAL]
+    
+    def _assess_complexity(self, requirements: List[Requirement], needed_types: List[SpecificationType]) -> str:
+        """Assess overall complexity based on requirements and needed types."""
+        req_count = len(requirements)
+        type_count = len(needed_types)
+        
+        # Count high-priority requirements
+        high_priority_count = sum(1 for req in requirements if req.priority in [req.priority.HIGH, req.priority.CRITICAL])
+        
+        if req_count <= 3 and type_count <= 2:
+            return "simple"
+        elif req_count <= 8 and type_count <= 4:
+            return "moderate"
+        else:
+            return "complex"
+    
+    def _estimate_effort(self, requirements: List[Requirement], complexity: str) -> str:
+        """Estimate development effort."""
+        effort_map = {
+            "simple": "low",
+            "moderate": "medium",
+            "complex": "high"
+        }
+        
+        base_effort = effort_map[complexity]
+        
+        # Adjust based on critical requirements
+        critical_count = sum(1 for req in requirements if req.priority == req.priority.CRITICAL)
+        if critical_count > 2 and base_effort != "high":
+            return "medium" if base_effort == "low" else "high"
+        
+        return base_effort
+    
+    def _identify_dependencies(self, requirements: List[Requirement]) -> List[str]:
+        """Identify potential dependencies between requirements."""
+        dependencies = []
+        
+        # Look for common entities across requirements
+        all_entities = []
+        for req in requirements:
+            all_entities.extend(req.entities)
+        
+        # Find entities mentioned in multiple requirements
+        from collections import Counter
+        entity_counts = Counter(all_entities)
+        shared_entities = [entity for entity, count in entity_counts.items() if count > 1]
+        
+        dependencies.extend(shared_entities)
+        
+        return list(set(dependencies))

--- a/specification_types.py
+++ b/specification_types.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+class SpecificationType(Enum):
+    BUSINESS_ANALYSIS = "business_analysis"
+    TEST_SPECS = "test_specs"
+    ARCHITECTURE_SPECS = "architecture_specs"
+    USER_STORIES = "user_stories"
+    API_DOCS = "api_docs"
+
+class ExportFormat(Enum):
+    MARKDOWN = "markdown"
+    JSON = "json"
+    HTML = "html"
+    PDF = "pdf"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,14 @@
+from .core.specification_generator import SpecificationGenerator
+from .clients.llm_client import OpenAIClient
+from .models.specification_models import (
+    SpecificationRequest, SpecificationOutput, OutputFormat, SpecificationType
+)
+
+__all__ = [
+    'SpecificationGenerator',
+    'OpenAIClient', 
+    'SpecificationRequest',
+    'SpecificationOutput',
+    'OutputFormat',
+    'SpecificationType'
+]

--- a/src/clients/llm_client.py
+++ b/src/clients/llm_client.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+import openai
+import os
+from ..models.specification_models import SpecificationRequest
+
+class LLMClient(ABC):
+    @abstractmethod
+    def generate_specification(self, request: SpecificationRequest) -> str:
+        pass
+
+class OpenAIClient(LLMClient):
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv('OPENAI_API_KEY')
+        if not self.api_key:
+            raise ValueError("OpenAI API key is required")
+        openai.api_key = self.api_key
+
+    def generate_specification(self, request: SpecificationRequest) -> str:
+        prompt = self._build_prompt(request)
+        
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-4",
+                messages=[
+                    {"role": "system", "content": self._get_system_prompt(request.specification_type)},
+                    {"role": "user", "content": prompt}
+                ],
+                max_tokens=4000,
+                temperature=0.3
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate specification: {str(e)}")
+
+    def _build_prompt(self, request: SpecificationRequest) -> str:
+        prompt_parts = [
+            f"Title: {request.title}",
+            f"Description: {request.description}",
+            f"Requirements:",
+        ]
+        
+        for i, req in enumerate(request.requirements, 1):
+            prompt_parts.append(f"{i}. {req}")
+        
+        if request.constraints:
+            prompt_parts.append("Constraints:")
+            for constraint in request.constraints:
+                prompt_parts.append(f"- {constraint}")
+        
+        if request.context:
+            prompt_parts.append("Additional Context:")
+            for key, value in request.context.items():
+                prompt_parts.append(f"- {key}: {value}")
+        
+        return "\n".join(prompt_parts)
+
+    def _get_system_prompt(self, spec_type: SpecificationType) -> str:
+        base_prompt = """You are an expert software architect and technical writer. 
+        Generate a comprehensive, well-structured specification document."""
+        
+        type_specific = {
+            SpecificationType.FUNCTIONAL: "Focus on functional requirements, user stories, and business logic.",
+            SpecificationType.TECHNICAL: "Focus on technical architecture, system design, and implementation details.",
+            SpecificationType.API: "Focus on API endpoints, request/response formats, and integration patterns.",
+            SpecificationType.DATABASE: "Focus on data models, relationships, and database schema design.",
+            SpecificationType.UI_UX: "Focus on user interface design, user experience, and interaction patterns."
+        }
+        
+        return f"{base_prompt} {type_specific.get(spec_type, '')}"

--- a/src/components/ChatInterface.css
+++ b/src/components/ChatInterface.css
@@ -1,0 +1,55 @@
+.chat-interface {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  max-width: 800px;
+  margin: 0 auto;
+  border: 1px solid #e1e5e9;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background: #f8f9fa;
+  border-bottom: 1px solid #e1e5e9;
+}
+
+.chat-header h2 {
+  margin: 0;
+  color: #2c3e50;
+}
+
+.connection-status {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.connection-status.connected {
+  color: #27ae60;
+}
+
+.connection-status.disconnected {
+  color: #e74c3c;
+}
+
+.error-banner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  background: #fee;
+  color: #c53030;
+  border-bottom: 1px solid #fed7d7;
+}
+
+.error-banner button {
+  background: none;
+  border: none;
+  color: #c53030;
+  cursor: pointer;
+  font-size: 1.25rem;
+}

--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -1,0 +1,95 @@
+import React, { useState, useCallback } from 'react';
+import { Message } from '../types/chat';
+import { MessageList } from './MessageList';
+import { MessageInput } from './MessageInput';
+import { useChatSocket } from '../hooks/useChatSocket';
+import { chatService } from '../services/chatService';
+import './ChatInterface.css';
+
+export const ChatInterface: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleMessageReceived = useCallback((message: Message) => {
+    setMessages(prev => [...prev, message]);
+  }, []);
+
+  const { isConnected, sendMessage, isTyping } = useChatSocket(handleMessageReceived);
+
+  const handleSendMessage = async (content: string) => {
+    try {
+      setError(null);
+      
+      // Create user message
+      const userMessage: Message = {
+        id: chatService.generateMessageId(),
+        content,
+        sender: 'user',
+        timestamp: new Date(),
+        status: 'sending'
+      };
+
+      // Add to local state immediately
+      setMessages(prev => [...prev, userMessage]);
+
+      // Send via WebSocket if connected, otherwise use HTTP
+      if (isConnected) {
+        sendMessage(userMessage);
+        // Update status to sent
+        setMessages(prev => 
+          prev.map(msg => 
+            msg.id === userMessage.id 
+              ? { ...msg, status: 'sent' }
+              : msg
+          )
+        );
+      } else {
+        // Fallback to HTTP API
+        await chatService.sendMessage(content);
+        setMessages(prev => 
+          prev.map(msg => 
+            msg.id === userMessage.id 
+              ? { ...msg, status: 'sent' }
+              : msg
+          )
+        );
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send message');
+      // Mark message as failed
+      setMessages(prev => 
+        prev.map(msg => 
+          msg.sender === 'user' && msg.status === 'sending'
+            ? { ...msg, status: 'error' }
+            : msg
+        )
+      );
+    }
+  };
+
+  return (
+    <div className="chat-interface">
+      <div className="chat-header">
+        <h2>Chat Assistant</h2>
+        <div className={`connection-status ${isConnected ? 'connected' : 'disconnected'}`}>
+          {isConnected ? '🟢 Connected' : '🔴 Disconnected'}
+        </div>
+      </div>
+      
+      {error && (
+        <div className="error-banner">
+          {error}
+          <button onClick={() => setError(null)}>×</button>
+        </div>
+      )}
+      
+      <MessageList messages={messages} isTyping={isTyping} />
+      
+      <MessageInput 
+        onSendMessage={handleSendMessage}
+        disabled={!isConnected}
+        placeholder={isConnected ? "Type your message..." : "Connecting..."}
+      />
+    </div>
+  );
+};

--- a/src/components/MessageBubble.css
+++ b/src/components/MessageBubble.css
@@ -1,0 +1,49 @@
+.message-bubble {
+  max-width: 70%;
+  margin-bottom: 0.5rem;
+}
+
+.message-bubble.user {
+  align-self: flex-end;
+  margin-left: auto;
+}
+
+.message-bubble.assistant {
+  align-self: flex-start;
+}
+
+.message-content {
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.message-bubble.user .message-content {
+  background: #007bff;
+  color: white;
+  border-bottom-right-radius: 0.25rem;
+}
+
+.message-bubble.assistant .message-content {
+  background: #f1f3f4;
+  color: #2c3e50;
+  border-bottom-left-radius: 0.25rem;
+}
+
+.message-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #6c757d;
+}
+
+.message-bubble.user .message-meta {
+  justify-content: flex-end;
+}
+
+.message-status.error {
+  color: #e74c3c;
+}

--- a/src/components/MessageBubble.tsx
+++ b/src/components/MessageBubble.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Message } from '../types/chat';
+import './MessageBubble.css';
+
+interface MessageBubbleProps {
+  message: Message;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
+  const formatTime = (timestamp: Date) => {
+    return timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div className={`message-bubble ${message.sender}`}>
+      <div className="message-content">
+        {message.content}
+      </div>
+      <div className="message-meta">
+        <span className="message-time">{formatTime(message.timestamp)}</span>
+        {message.status === 'sending' && <span className="message-status">Sending...</span>}
+        {message.status === 'error' && <span className="message-status error">Failed</span>}
+      </div>
+    </div>
+  );
+};

--- a/src/components/MessageInput.tsx
+++ b/src/components/MessageInput.tsx
@@ -1,0 +1,52 @@
+import React, { useState, KeyboardEvent } from 'react';
+import './MessageInput.css';
+
+interface MessageInputProps {
+  onSendMessage: (content: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export const MessageInput: React.FC<MessageInputProps> = ({ 
+  onSendMessage, 
+  disabled = false,
+  placeholder = "Type your message..." 
+}) => {
+  const [input, setInput] = useState('');
+
+  const handleSend = () => {
+    const trimmedInput = input.trim();
+    if (trimmedInput && !disabled) {
+      onSendMessage(trimmedInput);
+      setInput('');
+    }
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="message-input">
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyPress={handleKeyPress}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className="input-field"
+      />
+      <button
+        onClick={handleSend}
+        disabled={disabled || !input.trim()}
+        className="send-button"
+      >
+        Send
+      </button>
+    </div>
+  );
+};

--- a/src/components/MessageList.css
+++ b/src/components/MessageList.css
@@ -1,0 +1,37 @@
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #6c757d;
+  font-style: italic;
+}
+
+.typing-dots {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.typing-dots span {
+  width: 6px;
+  height: 6px;
+  background: #6c757d;
+  border-radius: 50%;
+  animation: typing 1.4s infinite ease-in-out;
+}
+
+.typing-dots span:nth-child(1) { animation-delay: -0.32s; }
+.typing-dots span:nth-child(2) { animation-delay: -0.16s; }
+
+@keyframes typing {
+  0%, 80%, 100% { transform: scale(0); }
+  40% { transform: scale(1); }
+}

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef } from 'react';
+import { Message } from '../types/chat';
+import { MessageBubble } from './MessageBubble';
+import './MessageList.css';
+
+interface MessageListProps {
+  messages: Message[];
+  isTyping: boolean;
+}
+
+export const MessageList: React.FC<MessageListProps> = ({ messages, isTyping }) => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = () => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, isTyping]);
+
+  return (
+    <div className="message-list">
+      {messages.map((message) => (
+        <MessageBubble key={message.id} message={message} />
+      ))}
+      {isTyping && (
+        <div className="typing-indicator">
+          <div className="typing-dots">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+          <span className="typing-text">Assistant is typing...</span>
+        </div>
+      )}
+      <div ref={messagesEndRef} />
+    </div>
+  );
+};

--- a/src/components/chat/ChatContainer.css
+++ b/src/components/chat/ChatContainer.css
@@ -1,0 +1,33 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 600px;
+  border: 1px solid #e1e5e9;
+  border-radius: 8px;
+  background: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.chat-container__header {
+  padding: 16px;
+  border-bottom: 1px solid #e1e5e9;
+  background: #f8f9fa;
+}
+
+.chat-container__header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+
+.chat-container__error {
+  margin-top: 8px;
+  padding: 8px 12px;
+  background: #fee;
+  border: 1px solid #fcc;
+  border-radius: 4px;
+  color: #c33;
+  font-size: 14px;
+}

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { MessageList } from './MessageList';
+import { MessageInput } from './MessageInput';
+import { chatService } from './ChatService';
+import { chatStore } from './ChatStore';
+import { ChatState, ChatMessage } from './types';
+import './ChatContainer.css';
+
+export const ChatContainer: React.FC = () => {
+  const [state, setState] = useState<ChatState>(chatStore.getState());
+
+  useEffect(() => {
+    const unsubscribe = chatStore.subscribe(setState);
+    
+    // Load initial messages
+    loadMessages();
+    
+    return unsubscribe;
+  }, []);
+
+  const loadMessages = async (): Promise<void> => {
+    try {
+      chatStore.setLoading(true);
+      chatStore.setError(null);
+      const messages = await chatService.getMessages();
+      messages.forEach(message => chatStore.addMessage(message));
+    } catch (error) {
+      chatStore.setError(error instanceof Error ? error.message : 'Failed to load messages');
+    } finally {
+      chatStore.setLoading(false);
+    }
+  };
+
+  const handleSendMessage = async (content: string): Promise<void> => {
+    // Add user message immediately
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      content,
+      timestamp: new Date(),
+      sender: 'user',
+      status: 'sending',
+    };
+    
+    chatStore.addMessage(userMessage);
+    chatStore.setLoading(true);
+    chatStore.setError(null);
+
+    try {
+      // Send message and get response
+      const response = await chatService.sendMessage(content);
+      
+      // Update user message status
+      chatStore.updateMessage(userMessage.id, { status: 'sent' });
+      
+      // Add assistant response
+      chatStore.addMessage(response);
+    } catch (error) {
+      chatStore.updateMessage(userMessage.id, { status: 'error' });
+      chatStore.setError(error instanceof Error ? error.message : 'Failed to send message');
+    } finally {
+      chatStore.setLoading(false);
+    }
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-container__header">
+        <h2>Chat Assistant</h2>
+        {state.error && (
+          <div className="chat-container__error">
+            {state.error}
+          </div>
+        )}
+      </div>
+      
+      <MessageList 
+        messages={state.messages} 
+        isLoading={state.isLoading} 
+      />
+      
+      <MessageInput 
+        onSendMessage={handleSendMessage}
+        disabled={state.isLoading}
+      />
+    </div>
+  );
+};

--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -1,87 +1,120 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { ChatStateProvider } from './ChatStateContext';
 import { MessageList } from './MessageList';
 import { MessageInput } from './MessageInput';
-import { chatService } from './ChatService';
-import { chatStore } from './ChatStore';
-import { ChatState, ChatMessage } from './types';
-import './ChatContainer.css';
+import { SpecificationPanel } from './SpecificationPanel';
+import { ProjectSelector } from './ProjectSelector';
+import { useChatWebSocket } from '../hooks/useChatWebSocket';
+import { useSpecificationSync } from '../hooks/useSpecificationSync';
+import { ChatMessage, Project, Specification } from '../types';
 
-export const ChatContainer: React.FC = () => {
-  const [state, setState] = useState<ChatState>(chatStore.getState());
+interface ChatContainerProps {
+  initialProject?: Project;
+  onSpecificationUpdate?: (spec: Specification) => void;
+}
+
+export const ChatContainer: React.FC<ChatContainerProps> = ({
+  initialProject,
+  onSpecificationUpdate
+}) => {
+  const [selectedProject, setSelectedProject] = useState<Project | null>(initialProject || null);
+  const [isSpecPanelOpen, setIsSpecPanelOpen] = useState(true);
+
+  const {
+    messages,
+    isConnected,
+    sendMessage,
+    clearChat,
+    isTyping
+  } = useChatWebSocket(selectedProject?.id);
+
+  const {
+    currentSpecification,
+    updateSpecification,
+    syncStatus
+  } = useSpecificationSync(selectedProject?.id);
+
+  const handleProjectChange = useCallback((project: Project) => {
+    setSelectedProject(project);
+    clearChat();
+  }, [clearChat]);
+
+  const handleMessageSend = useCallback((content: string, attachments?: File[]) => {
+    if (!selectedProject) {
+      throw new Error('No project selected');
+    }
+    
+    sendMessage({
+      content,
+      attachments,
+      projectId: selectedProject.id,
+      timestamp: new Date()
+    });
+  }, [selectedProject, sendMessage]);
 
   useEffect(() => {
-    const unsubscribe = chatStore.subscribe(setState);
-    
-    // Load initial messages
-    loadMessages();
-    
-    return unsubscribe;
-  }, []);
-
-  const loadMessages = async (): Promise<void> => {
-    try {
-      chatStore.setLoading(true);
-      chatStore.setError(null);
-      const messages = await chatService.getMessages();
-      messages.forEach(message => chatStore.addMessage(message));
-    } catch (error) {
-      chatStore.setError(error instanceof Error ? error.message : 'Failed to load messages');
-    } finally {
-      chatStore.setLoading(false);
+    if (currentSpecification && onSpecificationUpdate) {
+      onSpecificationUpdate(currentSpecification);
     }
-  };
+  }, [currentSpecification, onSpecificationUpdate]);
 
-  const handleSendMessage = async (content: string): Promise<void> => {
-    // Add user message immediately
-    const userMessage: ChatMessage = {
-      id: `user-${Date.now()}`,
-      content,
-      timestamp: new Date(),
-      sender: 'user',
-      status: 'sending',
-    };
-    
-    chatStore.addMessage(userMessage);
-    chatStore.setLoading(true);
-    chatStore.setError(null);
-
-    try {
-      // Send message and get response
-      const response = await chatService.sendMessage(content);
-      
-      // Update user message status
-      chatStore.updateMessage(userMessage.id, { status: 'sent' });
-      
-      // Add assistant response
-      chatStore.addMessage(response);
-    } catch (error) {
-      chatStore.updateMessage(userMessage.id, { status: 'error' });
-      chatStore.setError(error instanceof Error ? error.message : 'Failed to send message');
-    } finally {
-      chatStore.setLoading(false);
-    }
-  };
+  if (!selectedProject) {
+    return (
+      <div className="chat-container-empty">
+        <ProjectSelector onProjectSelect={setSelectedProject} />
+      </div>
+    );
+  }
 
   return (
-    <div className="chat-container">
-      <div className="chat-container__header">
-        <h2>Chat Assistant</h2>
-        {state.error && (
-          <div className="chat-container__error">
-            {state.error}
+    <ChatStateProvider
+      projectId={selectedProject.id}
+      initialMessages={messages}
+      specification={currentSpecification}
+    >
+      <div className="chat-container">
+        <div className="chat-header">
+          <ProjectSelector
+            selectedProject={selectedProject}
+            onProjectSelect={handleProjectChange}
+          />
+          <div className="chat-controls">
+            <button
+              onClick={() => setIsSpecPanelOpen(!isSpecPanelOpen)}
+              className="toggle-spec-panel"
+            >
+              {isSpecPanelOpen ? 'Hide' : 'Show'} Specification
+            </button>
+            <div className={`connection-status ${isConnected ? 'connected' : 'disconnected'}`}>
+              {isConnected ? '🟢' : '🔴'}
+            </div>
           </div>
-        )}
+        </div>
+
+        <div className="chat-body">
+          <div className="chat-main">
+            <MessageList
+              messages={messages}
+              isTyping={isTyping}
+              onSpecificationUpdate={updateSpecification}
+            />
+            <MessageInput
+              onSendMessage={handleMessageSend}
+              disabled={!isConnected}
+              placeholder={`Describe your ${selectedProject.name} requirements...`}
+            />
+          </div>
+
+          {isSpecPanelOpen && (
+            <SpecificationPanel
+              specification={currentSpecification}
+              syncStatus={syncStatus}
+              onSpecificationChange={updateSpecification}
+              projectId={selectedProject.id}
+            />
+          )}
+        </div>
       </div>
-      
-      <MessageList 
-        messages={state.messages} 
-        isLoading={state.isLoading} 
-      />
-      
-      <MessageInput 
-        onSendMessage={handleSendMessage}
-        disabled={state.isLoading}
-      />
-    </div>
+    </ChatStateProvider>
   );
 };

--- a/src/components/chat/ChatService.ts
+++ b/src/components/chat/ChatService.ts
@@ -1,0 +1,53 @@
+import { ChatMessage, ChatService } from './types';
+
+class DefaultChatService implements ChatService {
+  private apiBase: string;
+
+  constructor(apiBase: string = '/api/chat') {
+    this.apiBase = apiBase;
+  }
+
+  async sendMessage(content: string): Promise<ChatMessage> {
+    if (!content.trim()) {
+      throw new Error('Message content cannot be empty');
+    }
+
+    const response = await fetch(`${this.apiBase}/messages`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content: content.trim() }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to send message: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return {
+      id: data.id || Date.now().toString(),
+      content: data.content || content,
+      timestamp: new Date(data.timestamp || Date.now()),
+      sender: data.sender || 'assistant',
+    };
+  }
+
+  async getMessages(): Promise<ChatMessage[]> {
+    const response = await fetch(`${this.apiBase}/messages`);
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch messages: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    return data.map((msg: any) => ({
+      id: msg.id,
+      content: msg.content,
+      timestamp: new Date(msg.timestamp),
+      sender: msg.sender,
+    }));
+  }
+}
+
+export const chatService = new DefaultChatService();

--- a/src/components/chat/ChatStateContext.tsx
+++ b/src/components/chat/ChatStateContext.tsx
@@ -1,0 +1,122 @@
+import React, { createContext, useContext, useReducer, ReactNode } from 'react';
+import { ChatMessage, Specification, ChatState, ChatAction } from '../types';
+
+interface ChatStateContextType {
+  state: ChatState;
+  dispatch: React.Dispatch<ChatAction>;
+  addMessage: (message: ChatMessage) => void;
+  updateSpecification: (spec: Partial<Specification>) => void;
+  setTyping: (isTyping: boolean) => void;
+  clearMessages: () => void;
+}
+
+const ChatStateContext = createContext<ChatStateContextType | null>(null);
+
+const chatReducer = (state: ChatState, action: ChatAction): ChatState => {
+  switch (action.type) {
+    case 'ADD_MESSAGE':
+      return {
+        ...state,
+        messages: [...state.messages, action.payload],
+        lastActivity: new Date()
+      };
+    
+    case 'UPDATE_SPECIFICATION':
+      return {
+        ...state,
+        specification: {
+          ...state.specification,
+          ...action.payload,
+          lastModified: new Date()
+        }
+      };
+    
+    case 'SET_TYPING':
+      return {
+        ...state,
+        isTyping: action.payload
+      };
+    
+    case 'CLEAR_MESSAGES':
+      return {
+        ...state,
+        messages: [],
+        lastActivity: new Date()
+      };
+    
+    case 'SET_ERROR':
+      return {
+        ...state,
+        error: action.payload
+      };
+    
+    default:
+      return state;
+  }
+};
+
+interface ChatStateProviderProps {
+  children: ReactNode;
+  projectId: string;
+  initialMessages?: ChatMessage[];
+  specification?: Specification;
+}
+
+export const ChatStateProvider: React.FC<ChatStateProviderProps> = ({
+  children,
+  projectId,
+  initialMessages = [],
+  specification
+}) => {
+  const [state, dispatch] = useReducer(chatReducer, {
+    projectId,
+    messages: initialMessages,
+    specification: specification || {
+      id: '',
+      projectId,
+      content: '',
+      sections: [],
+      lastModified: new Date()
+    },
+    isTyping: false,
+    lastActivity: new Date(),
+    error: null
+  });
+
+  const addMessage = (message: ChatMessage) => {
+    dispatch({ type: 'ADD_MESSAGE', payload: message });
+  };
+
+  const updateSpecification = (spec: Partial<Specification>) => {
+    dispatch({ type: 'UPDATE_SPECIFICATION', payload: spec });
+  };
+
+  const setTyping = (isTyping: boolean) => {
+    dispatch({ type: 'SET_TYPING', payload: isTyping });
+  };
+
+  const clearMessages = () => {
+    dispatch({ type: 'CLEAR_MESSAGES' });
+  };
+
+  return (
+    <ChatStateContext.Provider value={{
+      state,
+      dispatch,
+      addMessage,
+      updateSpecification,
+      setTyping,
+      clearMessages
+    }}>
+      {children}
+    </ChatStateContext.Provider>
+  );
+};
+
+export const useChatState = (): ChatStateContextType => {
+  const context = useContext(ChatStateContext);
+  if (!context) {
+    throw new Error('useChatState must be used within ChatStateProvider');
+  }
+  return context;
+};

--- a/src/components/chat/ChatStore.ts
+++ b/src/components/chat/ChatStore.ts
@@ -1,0 +1,59 @@
+import { ChatMessage, ChatState } from './types';
+
+class ChatStore {
+  private state: ChatState = {
+    messages: [],
+    isLoading: false,
+    error: null,
+  };
+
+  private listeners: Array<(state: ChatState) => void> = [];
+
+  getState(): ChatState {
+    return { ...this.state };
+  }
+
+  subscribe(listener: (state: ChatState) => void): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const index = this.listeners.indexOf(listener);
+      if (index > -1) {
+        this.listeners.splice(index, 1);
+      }
+    };
+  }
+
+  private notify(): void {
+    this.listeners.forEach(listener => listener(this.getState()));
+  }
+
+  addMessage(message: ChatMessage): void {
+    this.state.messages.push(message);
+    this.notify();
+  }
+
+  updateMessage(id: string, updates: Partial<ChatMessage>): void {
+    const index = this.state.messages.findIndex(msg => msg.id === id);
+    if (index > -1) {
+      this.state.messages[index] = { ...this.state.messages[index], ...updates };
+      this.notify();
+    }
+  }
+
+  setLoading(isLoading: boolean): void {
+    this.state.isLoading = isLoading;
+    this.notify();
+  }
+
+  setError(error: string | null): void {
+    this.state.error = error;
+    this.notify();
+  }
+
+  clearMessages(): void {
+    this.state.messages = [];
+    this.notify();
+  }
+}
+
+export const chatStore = new ChatStore();

--- a/src/components/chat/Message.tsx
+++ b/src/components/chat/Message.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { ChatMessage } from './types';
+import './Message.css';
+
+interface MessageProps {
+  message: ChatMessage;
+}
+
+export const Message: React.FC<MessageProps> = ({ message }) => {
+  const formatTime = (timestamp: Date): string => {
+    return timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+
+  return (
+    <div className={`message message--${message.sender}`}>
+      <div className="message__content">
+        {message.content}
+      </div>
+      <div className="message__meta">
+        <span className="message__time">{formatTime(message.timestamp)}</span>
+        {message.status && (
+          <span className={`message__status message__status--${message.status}`}>
+            {message.status}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,0 +1,53 @@
+import React, { useState, KeyboardEvent } from 'react';
+import './MessageInput.css';
+
+interface MessageInputProps {
+  onSendMessage: (content: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export const MessageInput: React.FC<MessageInputProps> = ({
+  onSendMessage,
+  disabled = false,
+  placeholder = "Type your message...",
+}) => {
+  const [content, setContent] = useState('');
+
+  const handleSend = (): void => {
+    const trimmedContent = content.trim();
+    if (trimmedContent && !disabled) {
+      onSendMessage(trimmedContent);
+      setContent('');
+    }
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="message-input">
+      <textarea
+        className="message-input__field"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyPress={handleKeyPress}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+      />
+      <button
+        className="message-input__send"
+        onClick={handleSend}
+        disabled={disabled || !content.trim()}
+        type="button"
+      >
+        Send
+      </button>
+    </div>
+  );
+};

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,53 +1,129 @@
-import React, { useState, KeyboardEvent } from 'react';
-import './MessageInput.css';
+import React, { useState, useRef, KeyboardEvent } from 'react';
+import { AttachmentHandler } from './AttachmentHandler';
 
 interface MessageInputProps {
-  onSendMessage: (content: string) => void;
+  onSendMessage: (content: string, attachments?: File[]) => void;
   disabled?: boolean;
   placeholder?: string;
+  maxLength?: number;
 }
 
 export const MessageInput: React.FC<MessageInputProps> = ({
   onSendMessage,
   disabled = false,
   placeholder = "Type your message...",
+  maxLength = 2000
 }) => {
-  const [content, setContent] = useState('');
+  const [message, setMessage] = useState('');
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleSend = (): void => {
-    const trimmedContent = content.trim();
-    if (trimmedContent && !disabled) {
-      onSendMessage(trimmedContent);
-      setContent('');
+  const handleSubmit = async () => {
+    const trimmedMessage = message.trim();
+    
+    if (!trimmedMessage && attachments.length === 0) {
+      return;
+    }
+
+    if (trimmedMessage.length > maxLength) {
+      throw new Error(`Message too long. Maximum ${maxLength} characters allowed.`);
+    }
+
+    setIsSubmitting(true);
+    
+    try {
+      await onSendMessage(trimmedMessage, attachments);
+      setMessage('');
+      setAttachments([]);
+      
+      // Reset textarea height
+      if (textareaRef.current) {
+        textareaRef.current.style.height = 'auto';
+      }
+    } catch (error) {
+      console.error('Failed to send message:', error);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+  const handleKeyPress = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleSend();
+      handleSubmit();
     }
+  };
+
+  const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+    
+    // Auto-resize textarea
+    const textarea = e.target;
+    textarea.style.height = 'auto';
+    textarea.style.height = `${Math.min(textarea.scrollHeight, 120)}px`;
+  };
+
+  const removeAttachment = (index: number) => {
+    setAttachments(prev => prev.filter((_, i) => i !== index));
   };
 
   return (
-    <div className="message-input">
-      <textarea
-        className="message-input__field"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        onKeyPress={handleKeyPress}
-        placeholder={placeholder}
-        disabled={disabled}
-        rows={1}
-      />
-      <button
-        className="message-input__send"
-        onClick={handleSend}
-        disabled={disabled || !content.trim()}
-        type="button"
-      >
-        Send
-      </button>
+    <div className="message-input-container">
+      {attachments.length > 0 && (
+        <div className="attachments-preview">
+          {attachments.map((file, index) => (
+            <div key={index} className="attachment-item">
+              <span className="attachment-name">{file.name}</span>
+              <button
+                onClick={() => removeAttachment(index)}
+                className="remove-attachment"
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      
+      <div className="input-row">
+        <AttachmentHandler
+          onAttachmentsChange={setAttachments}
+          maxFiles={5}
+          maxFileSize={10 * 1024 * 1024} // 10MB
+        />
+        
+        <textarea
+          ref={textareaRef}
+          value={message}
+          onChange={handleTextareaChange}
+          onKeyPress={handleKeyPress}
+          placeholder={placeholder}
+          disabled={disabled || isSubmitting}
+          className="message-textarea"
+          rows={1}
+          maxLength={maxLength}
+        />
+        
+        <button
+          onClick={handleSubmit}
+          disabled={disabled || isSubmitting || (!message.trim() && attachments.length === 0)}
+          className="send-button"
+          type="button"
+        >
+          {isSubmitting ? '⏳' : '📤'}
+        </button>
+      </div>
+      
+      <div className="input-footer">
+        <span className="character-count">
+          {message.length}/{maxLength}
+        </span>
+        <span className="input-hint">
+          Press Enter to send, Shift+Enter for new line
+        </span>
+      </div>
     </div>
   );
 };

--- a/src/components/chat/MessageList.css
+++ b/src/components/chat/MessageList.css
@@ -1,0 +1,23 @@
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.message-list__content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message-list__loading {
+  display: flex;
+  justify-content: center;
+  padding: 8px;
+}
+
+.loading-indicator {
+  color: #666;
+  font-style: italic;
+  font-size: 14px;
+}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,35 +1,57 @@
 import React, { useEffect, useRef } from 'react';
-import { Message } from './Message';
-import { ChatMessage } from './types';
-import './MessageList.css';
+import { MessageItem } from './MessageItem';
+import { TypingIndicator } from './TypingIndicator';
+import { useChatState } from './ChatStateContext';
+import { ChatMessage, Specification } from '../types';
 
 interface MessageListProps {
   messages: ChatMessage[];
-  isLoading?: boolean;
+  isTyping: boolean;
+  onSpecificationUpdate: (spec: Partial<Specification>) => void;
 }
 
-export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading = false }) => {
+export const MessageList: React.FC<MessageListProps> = ({
+  messages,
+  isTyping,
+  onSpecificationUpdate
+}) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { state } = useChatState();
 
-  const scrollToBottom = (): void => {
+  const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   };
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [messages, isTyping]);
+
+  const handleSpecificationExtract = (message: ChatMessage) => {
+    if (message.specificationUpdate) {
+      onSpecificationUpdate(message.specificationUpdate);
+    }
+  };
 
   return (
     <div className="message-list">
-      <div className="message-list__content">
-        {messages.map((message) => (
-          <Message key={message.id} message={message} />
-        ))}
-        {isLoading && (
-          <div className="message-list__loading">
-            <div className="loading-indicator">Assistant is typing...</div>
+      <div className="messages-container">
+        {messages.length === 0 && (
+          <div className="empty-state">
+            <h3>Start describing your project requirements</h3>
+            <p>I'll help you create a comprehensive specification document.</p>
           </div>
         )}
+        
+        {messages.map((message) => (
+          <MessageItem
+            key={message.id}
+            message={message}
+            onSpecificationExtract={handleSpecificationExtract}
+          />
+        ))}
+        
+        {isTyping && <TypingIndicator />}
+        
         <div ref={messagesEndRef} />
       </div>
     </div>

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef } from 'react';
+import { Message } from './Message';
+import { ChatMessage } from './types';
+import './MessageList.css';
+
+interface MessageListProps {
+  messages: ChatMessage[];
+  isLoading?: boolean;
+}
+
+export const MessageList: React.FC<MessageListProps> = ({ messages, isLoading = false }) => {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const scrollToBottom = (): void => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  return (
+    <div className="message-list">
+      <div className="message-list__content">
+        {messages.map((message) => (
+          <Message key={message.id} message={message} />
+        ))}
+        {isLoading && (
+          <div className="message-list__loading">
+            <div className="loading-indicator">Assistant is typing...</div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+    </div>
+  );
+};

--- a/src/components/chat/types.ts
+++ b/src/components/chat/types.ts
@@ -1,0 +1,18 @@
+export interface ChatMessage {
+  id: string;
+  content: string;
+  timestamp: Date;
+  sender: 'user' | 'assistant';
+  status?: 'sending' | 'sent' | 'error';
+}
+
+export interface ChatState {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export interface ChatService {
+  sendMessage(content: string): Promise<ChatMessage>;
+  getMessages(): Promise<ChatMessage[]>;
+}

--- a/src/core/specification_generator.py
+++ b/src/core/specification_generator.py
@@ -1,0 +1,98 @@
+import re
+from typing import List, Dict, Any
+from ..models.specification_models import (
+    SpecificationRequest, SpecificationOutput, SpecificationSection, OutputFormat
+)
+from ..clients.llm_client import LLMClient
+from ..services.validation_service import ValidationService
+from ..services.format_renderer import FormatRenderer
+
+class SpecificationGenerator:
+    def __init__(self, llm_client: LLMClient):
+        self.llm_client = llm_client
+        self.validation_service = ValidationService()
+
+    def generate(self, request: SpecificationRequest) -> str:
+        # Validate input
+        self.validation_service.validate_request(request)
+        
+        # Generate raw specification content
+        raw_content = self.llm_client.generate_specification(request)
+        
+        # Parse and structure the content
+        specification = self._parse_specification(raw_content, request)
+        
+        # Validate output
+        self.validation_service.validate_output(specification)
+        
+        # Render in requested format
+        return FormatRenderer.render(specification)
+
+    def _parse_specification(self, raw_content: str, request: SpecificationRequest) -> SpecificationOutput:
+        sections = self._extract_sections(raw_content)
+        metadata = self._extract_metadata(request, raw_content)
+        
+        return SpecificationOutput(
+            title=request.title,
+            specification_type=request.specification_type,
+            sections=sections,
+            metadata=metadata,
+            raw_content=raw_content,
+            format=request.output_format
+        )
+
+    def _extract_sections(self, content: str) -> List[SpecificationSection]:
+        sections = []
+        
+        # Split content by headers (assuming markdown-style headers)
+        header_pattern = r'^(#{1,6})\s+(.+)$'
+        lines = content.split('\n')
+        
+        current_section = None
+        current_content = []
+        
+        for line in lines:
+            header_match = re.match(header_pattern, line)
+            
+            if header_match:
+                # Save previous section if exists
+                if current_section:
+                    current_section.content = '\n'.join(current_content).strip()
+                    sections.append(current_section)
+                
+                # Start new section
+                header_level = len(header_match.group(1))
+                title = header_match.group(2).strip()
+                current_section = SpecificationSection(title=title, content="")
+                current_content = []
+            else:
+                if current_section:
+                    current_content.append(line)
+        
+        # Add final section
+        if current_section:
+            current_section.content = '\n'.join(current_content).strip()
+            sections.append(current_section)
+        
+        # If no sections found, create a single section with all content
+        if not sections:
+            sections.append(SpecificationSection(
+                title="Specification",
+                content=content.strip()
+            ))
+        
+        return sections
+
+    def _extract_metadata(self, request: SpecificationRequest, raw_content: str) -> Dict[str, Any]:
+        return {
+            "generated_from": {
+                "requirements_count": len(request.requirements),
+                "has_constraints": bool(request.constraints),
+                "has_context": bool(request.context)
+            },
+            "content_stats": {
+                "character_count": len(raw_content),
+                "line_count": len(raw_content.split('\n')),
+                "word_count": len(raw_content.split())
+            }
+        }

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { Message } from '../types/chat';
+
+interface UseChatSocketReturn {
+  isConnected: boolean;
+  sendMessage: (message: Message) => void;
+  messages: Message[];
+  isTyping: boolean;
+}
+
+export const useChatSocket = (onMessageReceived: (message: Message) => void): UseChatSocketReturn => {
+  const [isConnected, setIsConnected] = useState(false);
+  const [isTyping, setIsTyping] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const ws = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const wsUrl = process.env.REACT_APP_WS_URL || 'ws://localhost:3001/ws';
+    ws.current = new WebSocket(wsUrl);
+
+    ws.current.onopen = () => {
+      setIsConnected(true);
+    };
+
+    ws.current.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        
+        if (data.type === 'message') {
+          const message: Message = {
+            id: data.id,
+            content: data.content,
+            sender: data.sender,
+            timestamp: new Date(data.timestamp),
+            status: 'sent'
+          };
+          onMessageReceived(message);
+        } else if (data.type === 'typing') {
+          setIsTyping(data.isTyping);
+        }
+      } catch (error) {
+        console.error('Failed to parse WebSocket message:', error);
+      }
+    };
+
+    ws.current.onclose = () => {
+      setIsConnected(false);
+    };
+
+    ws.current.onerror = (error) => {
+      console.error('WebSocket error:', error);
+      setIsConnected(false);
+    };
+
+    return () => {
+      ws.current?.close();
+    };
+  }, [onMessageReceived]);
+
+  const sendMessage = (message: Message) => {
+    if (ws.current?.readyState === WebSocket.OPEN) {
+      ws.current.send(JSON.stringify({
+        type: 'message',
+        ...message
+      }));
+    }
+  };
+
+  return { isConnected, sendMessage, messages, isTyping };
+};

--- a/src/models/specification_models.py
+++ b/src/models/specification_models.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Any
+from enum import Enum
+
+class OutputFormat(Enum):
+    JSON = "json"
+    MARKDOWN = "markdown"
+    YAML = "yaml"
+
+class SpecificationType(Enum):
+    FUNCTIONAL = "functional"
+    TECHNICAL = "technical"
+    API = "api"
+    DATABASE = "database"
+    UI_UX = "ui_ux"
+
+@dataclass
+class SpecificationRequest:
+    title: str
+    description: str
+    requirements: List[str]
+    specification_type: SpecificationType
+    context: Optional[Dict[str, Any]] = None
+    constraints: Optional[List[str]] = None
+    output_format: OutputFormat = OutputFormat.JSON
+
+@dataclass
+class SpecificationSection:
+    title: str
+    content: str
+    subsections: Optional[List['SpecificationSection']] = None
+
+@dataclass
+class SpecificationOutput:
+    title: str
+    specification_type: SpecificationType
+    sections: List[SpecificationSection]
+    metadata: Dict[str, Any]
+    raw_content: str
+    format: OutputFormat

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -1,0 +1,31 @@
+import { Message } from '../types/chat';
+
+class ChatService {
+  private baseUrl = process.env.REACT_APP_API_URL || 'http://localhost:3001';
+
+  async sendMessage(content: string): Promise<Message> {
+    if (!content.trim()) {
+      throw new Error('Message content cannot be empty');
+    }
+
+    const response = await fetch(`${this.baseUrl}/api/chat/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to send message: ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  generateMessageId(): string {
+    return `msg_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+}
+
+export const chatService = new ChatService();

--- a/src/services/format_renderer.py
+++ b/src/services/format_renderer.py
@@ -1,0 +1,83 @@
+import json
+import yaml
+from typing import Dict, Any
+from ..models.specification_models import SpecificationOutput, OutputFormat, SpecificationSection
+
+class FormatRenderer:
+    @staticmethod
+    def render(specification: SpecificationOutput) -> str:
+        if specification.format == OutputFormat.JSON:
+            return FormatRenderer._render_json(specification)
+        elif specification.format == OutputFormat.MARKDOWN:
+            return FormatRenderer._render_markdown(specification)
+        elif specification.format == OutputFormat.YAML:
+            return FormatRenderer._render_yaml(specification)
+        else:
+            raise ValueError(f"Unsupported format: {specification.format}")
+
+    @staticmethod
+    def _render_json(specification: SpecificationOutput) -> str:
+        data = {
+            "title": specification.title,
+            "type": specification.specification_type.value,
+            "sections": FormatRenderer._sections_to_dict(specification.sections),
+            "metadata": specification.metadata
+        }
+        return json.dumps(data, indent=2)
+
+    @staticmethod
+    def _render_markdown(specification: SpecificationOutput) -> str:
+        lines = [
+            f"# {specification.title}",
+            "",
+            f"**Type:** {specification.specification_type.value.title()}",
+            ""
+        ]
+        
+        for section in specification.sections:
+            lines.extend(FormatRenderer._section_to_markdown(section, level=2))
+        
+        if specification.metadata:
+            lines.extend(["", "## Metadata", ""])
+            for key, value in specification.metadata.items():
+                lines.append(f"- **{key}:** {value}")
+        
+        return "\n".join(lines)
+
+    @staticmethod
+    def _render_yaml(specification: SpecificationOutput) -> str:
+        data = {
+            "title": specification.title,
+            "type": specification.specification_type.value,
+            "sections": FormatRenderer._sections_to_dict(specification.sections),
+            "metadata": specification.metadata
+        }
+        return yaml.dump(data, default_flow_style=False, indent=2)
+
+    @staticmethod
+    def _sections_to_dict(sections: list) -> list:
+        result = []
+        for section in sections:
+            section_dict = {
+                "title": section.title,
+                "content": section.content
+            }
+            if section.subsections:
+                section_dict["subsections"] = FormatRenderer._sections_to_dict(section.subsections)
+            result.append(section_dict)
+        return result
+
+    @staticmethod
+    def _section_to_markdown(section: SpecificationSection, level: int = 2) -> list:
+        lines = [
+            f"{'#' * level} {section.title}",
+            "",
+            section.content,
+            ""
+        ]
+        
+        if section.subsections:
+            for subsection in section.subsections:
+                lines.extend(FormatRenderer._section_to_markdown(subsection, level + 1))
+        
+        return lines

--- a/src/services/validation_service.py
+++ b/src/services/validation_service.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+from ..models.specification_models import SpecificationRequest, SpecificationOutput
+
+class ValidationError(Exception):
+    pass
+
+class ValidationService:
+    @staticmethod
+    def validate_request(request: SpecificationRequest) -> None:
+        errors = []
+        
+        if not request.title or not request.title.strip():
+            errors.append("Title is required")
+        
+        if not request.description or not request.description.strip():
+            errors.append("Description is required")
+        
+        if not request.requirements or len(request.requirements) == 0:
+            errors.append("At least one requirement is required")
+        
+        for i, req in enumerate(request.requirements):
+            if not req or not req.strip():
+                errors.append(f"Requirement {i+1} cannot be empty")
+        
+        if errors:
+            raise ValidationError("; ".join(errors))
+
+    @staticmethod
+    def validate_output(output: SpecificationOutput) -> None:
+        errors = []
+        
+        if not output.title or not output.title.strip():
+            errors.append("Generated specification must have a title")
+        
+        if not output.sections or len(output.sections) == 0:
+            errors.append("Generated specification must have at least one section")
+        
+        for i, section in enumerate(output.sections):
+            if not section.title or not section.title.strip():
+                errors.append(f"Section {i+1} must have a title")
+            if not section.content or not section.content.strip():
+                errors.append(f"Section {i+1} must have content")
+        
+        if errors:
+            raise ValidationError("; ".join(errors))

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,13 @@
+export interface Message {
+  id: string;
+  content: string;
+  sender: 'user' | 'assistant';
+  timestamp: Date;
+  status?: 'sending' | 'sent' | 'error';
+}
+
+export interface ChatState {
+  messages: Message[];
+  isConnected: boolean;
+  isTyping: boolean;
+}

--- a/template_generator.py
+++ b/template_generator.py
@@ -1,0 +1,366 @@
+from enum import Enum
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+from datetime import datetime
+
+class TemplateType(Enum):
+    BUSINESS_ANALYSIS = "business_analysis"
+    TEST_SPECIFICATION = "test_specification"
+    ARCHITECTURE_SPEC = "architecture_spec"
+    TECHNICAL_REQUIREMENTS = "technical_requirements"
+
+@dataclass
+class TemplateSection:
+    title: str
+    content: str
+    level: int = 1
+    is_required: bool = True
+    placeholder: str = ""
+
+@dataclass
+class Template:
+    name: str
+    description: str
+    sections: List[TemplateSection] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat())
+
+class ValidationError(Exception):
+    pass
+
+class TemplateGenerator:
+    def __init__(self):
+        self.templates = SpecificationTemplates()
+    
+    def generate(self, template_type: TemplateType, project_name: str = "Project") -> Template:
+        if not isinstance(template_type, TemplateType):
+            raise ValidationError(f"Invalid template type: {template_type}")
+        
+        if not project_name or not project_name.strip():
+            raise ValidationError("Project name cannot be empty")
+        
+        generator_map = {
+            TemplateType.BUSINESS_ANALYSIS: self.templates.business_analysis,
+            TemplateType.TEST_SPECIFICATION: self.templates.test_specification,
+            TemplateType.ARCHITECTURE_SPEC: self.templates.architecture_spec,
+            TemplateType.TECHNICAL_REQUIREMENTS: self.templates.technical_requirements
+        }
+        
+        return generator_map[template_type](project_name.strip())
+
+class SpecificationTemplates:
+    def business_analysis(self, project_name: str) -> Template:
+        sections = [
+            TemplateSection("Executive Summary", 
+                          "Brief overview of the business analysis findings and recommendations.",
+                          level=1, placeholder="Summarize key findings in 2-3 paragraphs"),
+            
+            TemplateSection("Business Objectives", 
+                          "Primary business goals and success criteria.",
+                          level=1, placeholder="List 3-5 key business objectives"),
+            
+            TemplateSection("Current State Analysis", 
+                          "Assessment of existing business processes and systems.",
+                          level=1, placeholder="Describe current processes, pain points, and limitations"),
+            
+            TemplateSection("Stakeholder Analysis", 
+                          "Key stakeholders and their requirements.",
+                          level=1, placeholder="List stakeholders, roles, and their specific needs"),
+            
+            TemplateSection("Requirements Gathering", 
+                          "Functional and non-functional requirements.",
+                          level=1),
+            
+            TemplateSection("Functional Requirements", 
+                          "What the system must do.",
+                          level=2, placeholder="List specific functional requirements with IDs"),
+            
+            TemplateSection("Non-Functional Requirements", 
+                          "Performance, security, and quality requirements.",
+                          level=2, placeholder="Define performance, security, usability requirements"),
+            
+            TemplateSection("Gap Analysis", 
+                          "Differences between current and desired state.",
+                          level=1, placeholder="Identify gaps and their business impact"),
+            
+            TemplateSection("Proposed Solution", 
+                          "Recommended approach to address identified gaps.",
+                          level=1, placeholder="Describe proposed solution and rationale"),
+            
+            TemplateSection("Implementation Roadmap", 
+                          "Phased approach to implementation.",
+                          level=1, placeholder="Define phases, timelines, and dependencies"),
+            
+            TemplateSection("Risk Assessment", 
+                          "Potential risks and mitigation strategies.",
+                          level=1, placeholder="List risks with probability, impact, and mitigation plans"),
+            
+            TemplateSection("Success Metrics", 
+                          "Key performance indicators for measuring success.",
+                          level=1, placeholder="Define measurable success criteria")
+        ]
+        
+        return Template(
+            name=f"{project_name} - Business Analysis Document",
+            description="Comprehensive business analysis specification",
+            sections=sections,
+            metadata={
+                "type": "business_analysis",
+                "version": "1.0",
+                "project": project_name
+            }
+        )
+    
+    def test_specification(self, project_name: str) -> Template:
+        sections = [
+            TemplateSection("Test Overview", 
+                          "Purpose, scope, and objectives of testing.",
+                          level=1, placeholder="Define what will be tested and why"),
+            
+            TemplateSection("Test Scope", 
+                          "Features and components to be tested.",
+                          level=2, placeholder="List in-scope and out-of-scope items"),
+            
+            TemplateSection("Test Approach", 
+                          "Testing strategy and methodology.",
+                          level=2, placeholder="Describe testing levels, types, and techniques"),
+            
+            TemplateSection("Test Environment", 
+                          "Hardware, software, and network configurations.",
+                          level=1, placeholder="Specify test environment requirements"),
+            
+            TemplateSection("Test Data Requirements", 
+                          "Data needed for test execution.",
+                          level=1, placeholder="Define test data types and sources"),
+            
+            TemplateSection("Test Cases", 
+                          "Detailed test scenarios and expected results.",
+                          level=1),
+            
+            TemplateSection("Functional Test Cases", 
+                          "Tests for functional requirements.",
+                          level=2, placeholder="List test cases with steps and expected results"),
+            
+            TemplateSection("Non-Functional Test Cases", 
+                          "Performance, security, and usability tests.",
+                          level=2, placeholder="Define performance and security test scenarios"),
+            
+            TemplateSection("Test Execution Schedule", 
+                          "Timeline for test execution phases.",
+                          level=1, placeholder="Define test phases and milestones"),
+            
+            TemplateSection("Entry and Exit Criteria", 
+                          "Conditions for starting and completing testing.",
+                          level=1, placeholder="Define when testing can start and when it's complete"),
+            
+            TemplateSection("Defect Management", 
+                          "Process for reporting and tracking defects.",
+                          level=1, placeholder="Define defect lifecycle and severity levels"),
+            
+            TemplateSection("Test Deliverables", 
+                          "Documents and artifacts to be produced.",
+                          level=1, placeholder="List all test deliverables and their formats")
+        ]
+        
+        return Template(
+            name=f"{project_name} - Test Specification",
+            description="Comprehensive test specification document",
+            sections=sections,
+            metadata={
+                "type": "test_specification",
+                "version": "1.0",
+                "project": project_name
+            }
+        )
+    
+    def architecture_spec(self, project_name: str) -> Template:
+        sections = [
+            TemplateSection("Architecture Overview", 
+                          "High-level system architecture and design principles.",
+                          level=1, placeholder="Describe overall architecture vision and principles"),
+            
+            TemplateSection("System Context", 
+                          "External systems and interfaces.",
+                          level=1, placeholder="Define system boundaries and external dependencies"),
+            
+            TemplateSection("Architecture Drivers", 
+                          "Key requirements influencing architecture decisions.",
+                          level=1, placeholder="List quality attributes, constraints, and assumptions"),
+            
+            TemplateSection("System Architecture", 
+                          "Logical and physical system structure.",
+                          level=1),
+            
+            TemplateSection("Logical Architecture", 
+                          "High-level components and their relationships.",
+                          level=2, placeholder="Describe major components and their interactions"),
+            
+            TemplateSection("Physical Architecture", 
+                          "Deployment view and infrastructure components.",
+                          level=2, placeholder="Define deployment topology and infrastructure"),
+            
+            TemplateSection("Component Design", 
+                          "Detailed design of major components.",
+                          level=1, placeholder="Describe component responsibilities and interfaces"),
+            
+            TemplateSection("Data Architecture", 
+                          "Data models, storage, and flow.",
+                          level=1, placeholder="Define data models, storage strategy, and data flow"),
+            
+            TemplateSection("Security Architecture", 
+                          "Security controls and mechanisms.",
+                          level=1, placeholder="Define authentication, authorization, and security measures"),
+            
+            TemplateSection("Integration Architecture", 
+                          "APIs, messaging, and integration patterns.",
+                          level=1, placeholder="Describe integration patterns and API design"),
+            
+            TemplateSection("Technology Stack", 
+                          "Frameworks, libraries, and tools.",
+                          level=1, placeholder="List technologies with rationale for selection"),
+            
+            TemplateSection("Architecture Decisions", 
+                          "Key decisions and their rationale.",
+                          level=1, placeholder="Document ADRs (Architecture Decision Records)")
+        ]
+        
+        return Template(
+            name=f"{project_name} - Architecture Specification",
+            description="Comprehensive system architecture specification",
+            sections=sections,
+            metadata={
+                "type": "architecture_spec",
+                "version": "1.0",
+                "project": project_name
+            }
+        )
+    
+    def technical_requirements(self, project_name: str) -> Template:
+        sections = [
+            TemplateSection("Introduction", 
+                          "Purpose, scope, and audience of this document.",
+                          level=1, placeholder="Define document purpose and target audience"),
+            
+            TemplateSection("System Overview", 
+                          "High-level description of the system.",
+                          level=1, placeholder="Provide system context and key capabilities"),
+            
+            TemplateSection("Functional Requirements", 
+                          "What the system must do.",
+                          level=1),
+            
+            TemplateSection("User Requirements", 
+                          "Requirements from user perspective.",
+                          level=2, placeholder="Define user stories and use cases"),
+            
+            TemplateSection("System Requirements", 
+                          "Detailed functional system requirements.",
+                          level=2, placeholder="List specific system functions with IDs"),
+            
+            TemplateSection("Non-Functional Requirements", 
+                          "Quality attributes and constraints.",
+                          level=1),
+            
+            TemplateSection("Performance Requirements", 
+                          "Response time, throughput, and capacity.",
+                          level=2, placeholder="Define performance benchmarks and limits"),
+            
+            TemplateSection("Security Requirements", 
+                          "Authentication, authorization, and data protection.",
+                          level=2, placeholder="Specify security controls and compliance needs"),
+            
+            TemplateSection("Reliability Requirements", 
+                          "Availability, fault tolerance, and recovery.",
+                          level=2, placeholder="Define uptime, MTBF, and recovery requirements"),
+            
+            TemplateSection("Usability Requirements", 
+                          "User experience and accessibility.",
+                          level=2, placeholder="Define UX standards and accessibility requirements"),
+            
+            TemplateSection("Technical Constraints", 
+                          "Technology, platform, and integration constraints.",
+                          level=1, placeholder="List technical limitations and dependencies"),
+            
+            TemplateSection("Interface Requirements", 
+                          "External system interfaces and APIs.",
+                          level=1, placeholder="Define external interfaces and data formats"),
+            
+            TemplateSection("Data Requirements", 
+                          "Data models, storage, and migration needs.",
+                          level=1, placeholder="Specify data requirements and migration needs"),
+            
+            TemplateSection("Compliance Requirements", 
+                          "Regulatory and standards compliance.",
+                          level=1, placeholder="List applicable regulations and standards")
+        ]
+        
+        return Template(
+            name=f"{project_name} - Technical Requirements Specification",
+            description="Comprehensive technical requirements document",
+            sections=sections,
+            metadata={
+                "type": "technical_requirements",
+                "version": "1.0",
+                "project": project_name
+            }
+        )
+
+class TemplateFormatter:
+    @staticmethod
+    def to_markdown(template: Template) -> str:
+        if not template:
+            raise ValidationError("Template cannot be None")
+        
+        lines = [
+            f"# {template.name}",
+            "",
+            f"**Description:** {template.description}",
+            f"**Created:** {template.created_at}",
+            f"**Version:** {template.metadata.get('version', 'N/A')}",
+            ""
+        ]
+        
+        for section in template.sections:
+            header_prefix = "#" * (section.level + 1)
+            lines.append(f"{header_prefix} {section.title}")
+            lines.append("")
+            
+            if section.content:
+                lines.append(section.content)
+            
+            if section.placeholder:
+                lines.append(f"*{section.placeholder}*")
+            
+            lines.append("")
+        
+        return "\n".join(lines)
+    
+    @staticmethod
+    def to_plain_text(template: Template) -> str:
+        if not template:
+            raise ValidationError("Template cannot be None")
+        
+        lines = [
+            template.name.upper(),
+            "=" * len(template.name),
+            "",
+            f"Description: {template.description}",
+            f"Created: {template.created_at}",
+            f"Version: {template.metadata.get('version', 'N/A')}",
+            ""
+        ]
+        
+        for section in template.sections:
+            indent = "  " * (section.level - 1)
+            lines.append(f"{indent}{section.title}")
+            lines.append(f"{indent}{'-' * len(section.title)}")
+            
+            if section.content:
+                lines.append(f"{indent}{section.content}")
+            
+            if section.placeholder:
+                lines.append(f"{indent}[{section.placeholder}]")
+            
+            lines.append("")
+        
+        return "\n".join(lines)


### PR DESCRIPTION
## Task Description
Have the specification-expert subagent implement handlers for different specification types (business analysis, test specs, architecture specs, user stories, API docs) with customizable parameters and export options

## Automated Implementation
This PR was created by FDJ Code CLI using Claude Sonnet 4 via AWS Bedrock.

**Task ID:** `create-spec-types`  
**Branch:** `fix-create-spec-types-1757522546`  
**Provider:** `claude-bedrock`

---
*Generated by [FDJ Code CLI](https://github.com/durdan/dd-agentic-pipeline) • Powered by Claude Sonnet 4*
