### PR TITLE
Task database-schema: Create MongoDB schemas for sports events, teams, a

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -1,0 +1,38 @@
+const mongoose = require('mongoose');
+
+class DatabaseConnection {
+  constructor() {
+    this.connection = null;
+  }
+
+  async connect(uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/sportsdb') {
+    try {
+      this.connection = await mongoose.connect(uri, {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        maxPoolSize: 10,
+        serverSelectionTimeoutMS: 5000,
+        socketTimeoutMS: 45000,
+      });
+      
+      console.log('MongoDB connected successfully');
+      return this.connection;
+    } catch (error) {
+      console.error('MongoDB connection error:', error);
+      throw error;
+    }
+  }
+
+  async disconnect() {
+    if (this.connection) {
+      await mongoose.disconnect();
+      console.log('MongoDB disconnected');
+    }
+  }
+
+  isConnected() {
+    return mongoose.connection.readyState === 1;
+  }
+}
+
+module.exports = new DatabaseConnection();

--- a/models/Event.js
+++ b/models/Event.js
@@ -1,0 +1,87 @@
+const mongoose = require('mongoose');
+
+const eventSchema = new mongoose.Schema({
+  homeTeam: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Team',
+    required: true
+  },
+  awayTeam: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Team',
+    required: true
+  },
+  sport: {
+    type: String,
+    required: true,
+    enum: ['football', 'basketball', 'baseball', 'hockey', 'soccer'],
+    lowercase: true
+  },
+  league: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 50
+  },
+  season: {
+    type: String,
+    required: true,
+    match: /^\d{4}(-\d{4})?$/  // 2023 or 2023-2024
+  },
+  week: {
+    type: Number,
+    min: 1,
+    max: 52
+  },
+  scheduledDate: {
+    type: Date,
+    required: true
+  },
+  actualStartTime: Date,
+  venue: {
+    name: String,
+    city: String,
+    capacity: Number
+  },
+  status: {
+    type: String,
+    enum: ['scheduled', 'in_progress', 'completed', 'postponed', 'cancelled'],
+    default: 'scheduled'
+  },
+  score: {
+    home: {
+      type: Number,
+      min: 0,
+      default: 0
+    },
+    away: {
+      type: Number,
+      min: 0,
+      default: 0
+    }
+  },
+  attendance: {
+    type: Number,
+    min: 0
+  }
+}, {
+  timestamps: true
+});
+
+// Validation: teams must be different
+eventSchema.pre('save', function(next) {
+  if (this.homeTeam.equals(this.awayTeam)) {
+    next(new Error('Home team and away team cannot be the same'));
+  }
+  next();
+});
+
+// Indexes for efficient queries
+eventSchema.index({ scheduledDate: 1 });
+eventSchema.index({ homeTeam: 1, scheduledDate: 1 });
+eventSchema.index({ awayTeam: 1, scheduledDate: 1 });
+eventSchema.index({ league: 1, season: 1, scheduledDate: 1 });
+eventSchema.index({ sport: 1, status: 1, scheduledDate: 1 });
+eventSchema.index({ season: 1, week: 1 });
+
+module.exports = mongoose.model('Event', eventSchema);

--- a/models/Statistics.js
+++ b/models/Statistics.js
@@ -1,0 +1,68 @@
+const mongoose = require('mongoose');
+
+const statisticsSchema = new mongoose.Schema({
+  event: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Event',
+    required: true
+  },
+  team: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Team',
+    required: true
+  },
+  player: {
+    name: String,
+    position: String,
+    number: Number
+  },
+  sport: {
+    type: String,
+    required: true,
+    enum: ['football', 'basketball', 'baseball', 'hockey', 'soccer'],
+    lowercase: true
+  },
+  category: {
+    type: String,
+    required: true,
+    enum: ['team', 'player'],
+    lowercase: true
+  },
+  period: {
+    type: String,
+    enum: ['game', 'quarter', 'half', 'period', 'inning'],
+    default: 'game'
+  },
+  periodNumber: {
+    type: Number,
+    min: 1
+  },
+  stats: {
+    type: Map,
+    of: mongoose.Schema.Types.Mixed,
+    required: true
+  },
+  recordedAt: {
+    type: Date,
+    default: Date.now
+  }
+}, {
+  timestamps: true
+});
+
+// Validation: player stats must have player info
+statisticsSchema.pre('save', function(next) {
+  if (this.category === 'player' && !this.player?.name) {
+    next(new Error('Player statistics must include player name'));
+  }
+  next();
+});
+
+// Indexes for efficient queries
+statisticsSchema.index({ event: 1, team: 1, category: 1 });
+statisticsSchema.index({ team: 1, sport: 1, category: 1 });
+statisticsSchema.index({ 'player.name': 1, sport: 1 });
+statisticsSchema.index({ event: 1, period: 1, periodNumber: 1 });
+statisticsSchema.index({ sport: 1, category: 1, recordedAt: 1 });
+
+module.exports = mongoose.model('Statistics', statisticsSchema);

--- a/models/Team.js
+++ b/models/Team.js
@@ -1,0 +1,61 @@
+const mongoose = require('mongoose');
+
+const teamSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 100
+  },
+  shortName: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 10,
+    uppercase: true
+  },
+  league: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 50
+  },
+  sport: {
+    type: String,
+    required: true,
+    enum: ['football', 'basketball', 'baseball', 'hockey', 'soccer'],
+    lowercase: true
+  },
+  city: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 50
+  },
+  country: {
+    type: String,
+    required: true,
+    trim: true,
+    maxlength: 50,
+    default: 'USA'
+  },
+  founded: {
+    type: Number,
+    min: 1800,
+    max: new Date().getFullYear()
+  },
+  isActive: {
+    type: Boolean,
+    default: true
+  }
+}, {
+  timestamps: true
+});
+
+// Indexes for efficient queries
+teamSchema.index({ league: 1, sport: 1 });
+teamSchema.index({ shortName: 1 }, { unique: true });
+teamSchema.index({ name: 1 });
+teamSchema.index({ sport: 1, isActive: 1 });
+
+module.exports = mongoose.model('Team', teamSchema);

--- a/services/QueryHelpers.js
+++ b/services/QueryHelpers.js
@@ -1,0 +1,115 @@
+const Team = require('../models/Team');
+const Event = require('../models/Event');
+const Statistics = require('../models/Statistics');
+
+class QueryHelpers {
+  // Get events for a team within date range
+  static async getTeamEvents(teamId, startDate, endDate, options = {}) {
+    const query = {
+      $or: [{ homeTeam: teamId }, { awayTeam: teamId }],
+      scheduledDate: {
+        $gte: new Date(startDate),
+        $lte: new Date(endDate)
+      }
+    };
+
+    if (options.status) {
+      query.status = options.status;
+    }
+
+    return Event.find(query)
+      .populate('homeTeam awayTeam', 'name shortName')
+      .sort({ scheduledDate: 1 })
+      .limit(options.limit || 100);
+  }
+
+  // Get team statistics aggregated by sport
+  static async getTeamStats(teamId, sport, options = {}) {
+    const matchStage = {
+      team: teamId,
+      sport: sport,
+      category: 'team'
+    };
+
+    if (options.season) {
+      // Join with events to filter by season
+      const pipeline = [
+        { $match: matchStage },
+        {
+          $lookup: {
+            from: 'events',
+            localField: 'event',
+            foreignField: '_id',
+            as: 'eventData'
+          }
+        },
+        { $unwind: '$eventData' },
+        { $match: { 'eventData.season': options.season } }
+      ];
+
+      return Statistics.aggregate(pipeline);
+    }
+
+    return Statistics.find(matchStage)
+      .populate('event', 'scheduledDate season')
+      .sort({ recordedAt: -1 })
+      .limit(options.limit || 50);
+  }
+
+  // Get league standings helper
+  static async getLeagueStandings(league, season) {
+    return Event.aggregate([
+      {
+        $match: {
+          league: league,
+          season: season,
+          status: 'completed'
+        }
+      },
+      {
+        $facet: {
+          homeGames: [
+            {
+              $group: {
+                _id: '$homeTeam',
+                wins: {
+                  $sum: {
+                    $cond: [{ $gt: ['$score.home', '$score.away'] }, 1, 0]
+                  }
+                },
+                losses: {
+                  $sum: {
+                    $cond: [{ $lt: ['$score.home', '$score.away'] }, 1, 0]
+                  }
+                },
+                pointsFor: { $sum: '$score.home' },
+                pointsAgainst: { $sum: '$score.away' }
+              }
+            }
+          ],
+          awayGames: [
+            {
+              $group: {
+                _id: '$awayTeam',
+                wins: {
+                  $sum: {
+                    $cond: [{ $gt: ['$score.away', '$score.home'] }, 1, 0]
+                  }
+                },
+                losses: {
+                  $sum: {
+                    $cond: [{ $lt: ['$score.away', '$score.home'] }, 1, 0]
+                  }
+                },
+                pointsFor: { $sum: '$score.away' },
+                pointsAgainst: { $sum: '$score.home' }
+              }
+            }
+          ]
+        }
+      }
+    ]);
+  }
+}
+
+module.exports = QueryHelpers;


### PR DESCRIPTION
## Task Description
Create MongoDB schemas for sports events, teams, and statistics data with proper indexing for efficient queries. Use the code-analyzer subagent to review the existing database patterns in the repository and ensure consistency with current data modeling approaches

## Automated Implementation
This PR was created by FDJ Code CLI using Claude Sonnet 4 via AWS Bedrock.

**Task ID:** `database-schema`  
**Branch:** `fix-database-schema-1757599900`  
**Provider:** `claude-bedrock`

---
*Generated by [FDJ Code CLI](https://github.com/durdan/dd-agentic-pipeline) • Powered by Claude Sonnet 4*
